### PR TITLE
Fix OpenACC data sharing across OpenMP threads

### DIFF
--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -125,9 +125,9 @@ subroutine gronor_worker()
 
 #ifdef ACC
 
-!$acc data create(a,ta,tb,w1,w2,taa,u,w,wt,ev,rwork, &
-&diag,bdiag,cdiag,bsdiag,csdiag,sdiag,aaa,tt,aat,sm, &
-&workspace_d,workspace_i,workspace2_d,workspace_i4)
+!$acc data present(a,ta,tb,w1,w2,taa,u,w,wt,ev,rwork, &
+&diag,bdiag,cdiag,bsdiag,csdiag,sdiag,aaa,tt,aat,sm) &
+& create(workspace_d,workspace_i,workspace2_d,workspace_i4)
 #endif
 
   call gronor_worker_process()


### PR DESCRIPTION
## Summary
- avoid re-creating device arrays in every OpenMP thread
- use a `present` data clause when launching worker threads

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_6889129caec4832ab50cec41eb59d93a