### PR TITLE
Refactor GNOME electron bookkeeping into thread-local arrays

### DIFF
--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -28,7 +28,7 @@
 !!    @param[in] id2 : index of final matrix contribution
 !!    @date    2016
 
-subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,nelec,ntcl,ntop,nopen,nclose,iocopen,ninact,nact)
 
   use mpi
   use cidist
@@ -46,6 +46,8 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
   real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
   real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
+  integer, intent(inout) :: nelec(:),ntcl(:),ntop(:),nopen(:),nclose(:)
+  integer, intent(inout) :: iocopen(:,:),ninact(:),nact(:)
 
   external :: swatch,timer_start,timer_stop
 !  external :: MPI_iSend,MPI_Recv
@@ -329,7 +331,7 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
 618   format(//,' Entering GNOME :',i8,', for determinants',2i8)
 
       call timer_start(6)
-      call gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+      call gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,nelec,ntcl,ntop,nopen,nclose,iocopen,nact)
       call timer_stop(6)
 
       if(oterm) then

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -20,7 +20,7 @@
 !!
 
 
-subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,nelec,ntcl,ntop,nopen,nclose,iocopen,nact)
 
   use mpi
   use cidist
@@ -35,6 +35,8 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
   real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
+  integer, intent(inout) :: nelec(:),ntcl(:),ntop(:),nopen(:),nclose(:)
+  integer, intent(inout) :: iocopen(:,:),nact(:)
 
   external :: timer_start,timer_stop
   external :: gronor_dipole
@@ -87,7 +89,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     endif
 
     call timer_start(11)
-    call gronor_transvc(lfndbg,idet)
+    call gronor_transvc(lfndbg,idet,ntcl,ntop,nclose,nopen,iocopen)
     call timer_stop(11)
 
     call timer_start(12)
@@ -95,7 +97,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     call timer_stop(12)
 
     call timer_start(13)
-    call gronor_tranout(lfndbg,idet)
+    call gronor_tranout(lfndbg,idet,ntcl,ntop)
     call timer_stop(13)
 
     if(idbg.ge.20) write(lfndbg,606) idet

--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -204,10 +204,7 @@ module gnome_data
 
   integer :: nnucl,nbas,numint,numfiles
 
-  integer :: nelec(2),ntcl(2),ntop(2)
   integer :: nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb
-  integer :: nclose(2)
-  integer :: nopen(2),iocopen(100,2)
 
   character (len=80) :: text,name(2),namint(2)
   real (kind=8) :: potnuc,zNucTot
@@ -220,7 +217,7 @@ module gnome_data
   integer, allocatable :: ic(:),it(:),ictr(:)
   integer, allocatable :: icentn(:),itypen(:),icount(:),istand(:)
 
-  integer :: ninact(2),nact(2),mnact,ittr(3)
+  integer :: mnact,ittr(3)
 
   integer :: nbasis,mvec,nvec(2)
 

--- a/src/gnome/gronor_tranout.F90
+++ b/src/gnome/gronor_tranout.F90
@@ -19,12 +19,13 @@
 !! @date    2016
 !!
 
-subroutine gronor_tranout(lfndbg,idet)
+subroutine gronor_tranout(lfndbg,idet,ntcl,ntop)
   use cidist
   use gnome_parameters
   use gnome_data
   implicit none
-  integer :: idet, lfndbg
+  integer, intent(in) :: lfndbg,idet
+  integer, intent(inout) :: ntcl(:),ntop(:)
   integer :: ivc,ntvc,ibas,i
 
   ntvc=ntcl(idet)+ntop(idet)

--- a/src/gnome/gronor_transvc.F90
+++ b/src/gnome/gronor_transvc.F90
@@ -32,15 +32,18 @@
 !! @date    2016
 !!
 
-subroutine gronor_transvc(lfndbg,idet)
+subroutine gronor_transvc(lfndbg,idet,ntcl,ntop,nclose,nopen,iocopen)
   
   use cidist
   use gnome_data
   use gnome_parameters
   
   implicit none
-  
-  integer :: idet,m,n1,iop,ib,iv,lfndbg,k,i,l,im,ls,norbs
+
+  integer, intent(in) :: lfndbg,idet
+  integer, intent(inout) :: ntcl(:),ntop(:),nclose(:),nopen(:)
+  integer, intent(inout) :: iocopen(:,:)
+  integer :: m,n1,iop,ib,iv,k,i,l,im,ls,norbs
   if(idbg.ge.17) write(lfndbg,601)
 601 format(/,' Determinant Irrep  Nclose  Nopen OccActive',/)
 


### PR DESCRIPTION
## Summary
- localize electron bookkeeping arrays within `gronor_worker` and pass through call chain
- remove old global declarations from `gnome_data`

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `sudo apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e39ba3c14832a9c7216dee58fbe20