### PR TITLE
refactor: replace OpenACC with OpenMP target

### DIFF
--- a/src/gnome/gronor_cofac1.F90
+++ b/src/gnome/gronor_cofac1.F90
@@ -20,7 +20,8 @@
 !! @date    2016
 !!
 
-      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
+      !$omp declare target
+subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
       use cidist
       use gnome_parameters
       use gnome_data
@@ -47,9 +48,7 @@
 
 
       if(idbg.ge.90) then
-#ifdef ACC
-!$acc update host (a)
-#endif
+!$omp target update from(a)
         write(lfndbg,1601) nelecs,nelecs,mbasel
  1601   format(//,' SVD input matrix:',3i6,/)
         do j=1,nelecs
@@ -65,7 +64,7 @@
 
   !  Calculation of det(uw) by determination of the number of eigenvalues -2 of a=uw+transpose(uw)
  !!! the MOST TIME COMSUMING CONSUMING loop if this subroutine!!!
-! !$acc kernels present(u,w,a)
+! !$omp target teams distribute parallel do map(tofrom:u,w,a)
 !   do i=1,nelecs
 !     do j=1,i
 !       coef=0.0d0
@@ -76,17 +75,16 @@
 !       a(j,i)=coef
 !     enddo
 !   enddo
-! !$acc end kernels
+! !$omp end target teams distribute parallel do
       
   ! "do j=1,i" 导致 j 依赖 i , 编译器无法有效并行化。
   ! 直接写 “do j = 1, nelecs” ，计算量翻倍，但是有效并行，速度反而快。
   ! 因为多出来的计算量是放在原来就没占满的计算单元上！
 
-  !$acc parallel loop gang vector collapse(2) present(u, w, a) 
+  !$omp target teams distribute parallel do gang vector collapse(2) map(tofrom:u, w, a) 
   do i = 1, nelecs
     do j = 1, nelecs
       coef = 0.0d0
-      !$acc loop seq reduction(+:coef)
       do k = 1, nelecs
         coef = coef + u(i,k) * w(k,j) + u(j,k) * w(k,i)
       enddo
@@ -95,12 +93,11 @@
   enddo
 
   !可能的更快代码，但没有必要了。
-!   !$acc parallel loop gang vector collapse(2) present(u,w,a)
+!   !$omp target teams distribute parallel do gang vector collapse(2) map(tofrom:u,w,a)
 ! do i = 1, nelecs
 !   do j = 1, nelecs
 !     if (j <= i) then  ! 仅计算下三角
 !       coef = 0.0d0
-!       !$acc loop seq reduction(+:coef)
 !       do k = 1, nelecs
 !         coef = coef + u(i,k)*w(k,j) + u(j,k)*w(k,i)
 !       enddo
@@ -111,8 +108,7 @@
 ! enddo
       
       if(idbg.ge.90) then
-#ifdef ACC
-!$acc update host (u,w,a,ev)
+!$omp target update from(u,w,a,ev)
 #endif 
         write(lfndbg,601) (ev(i),i=1,nelecs)
  601    format(//,' Eigenvalues of diagonalized overlap matrix:',               &
@@ -147,9 +143,7 @@
 
       cmax=0.0d0
 
-#ifdef ACC
-!$acc kernels present(cdiag,diag,csdiag,sdiag,ev)
-#endif
+!$omp target teams distribute parallel do map(tofrom:cdiag,diag,csdiag,sdiag,ev)
       
       !  Calculation of det(a) and x and y
       
@@ -160,15 +154,11 @@
         csdiag(i)=sdiag(i)
       enddo
 
-#ifdef ACC
-!$acc end kernels
-#endif
+!$omp end target teams distribute parallel do
       if(cmax.le.0.01) call gronor_abort(310,"No overlap between m.o.s")
 
       if(idbg.ge.90) then
-#ifdef ACC
-!$acc update host (diag,cdiag,csdiag,sdiag)
-#endif
+!$omp target update from(diag,cdiag,csdiag,sdiag)
         write(lfndbg,604) (diag(i),cdiag(i),csdiag(i),sdiag(i),i=1,nelecs)
  604    format(//,' Diagonals:',//,(3x,4e20.12))
         flush(lfndbg)
@@ -180,9 +170,7 @@
       nz2=0
       deta=0.0d0
 
-#ifdef ACC
-!$acc update host(ev)
-#endif
+!$omp target update from(ev)
       do i=1,nelecs
         coefu=ev(i)
         if(abs(coefu) .le. cnorm) then
@@ -205,9 +193,7 @@
           deta=coef
           ising=0
 
-#ifdef ACC
-!$acc parallel loop gang collapse(2) present(ta,u,w,ev)
-#endif
+!$omp target teams distribute parallel do gang collapse(2) map(tofrom:ta,u,w,ev)
           do i=1,nelecs
             do j=1,nelecs
               coefu=0.0d0
@@ -217,17 +203,13 @@
               ta(i,j)=coefu*0.5d0
             enddo
           enddo
-#ifdef ACC
-!$acc end parallel loop
-#endif
+!$omp end target teams distribute parallel do
           call timer_stop(44)
           return
           ising=1
         endif
 
-#ifdef ACC
-!$acc kernels present(ta,u,w,ev,cdiag,diag,csdiag,sdiag)
-#endif
+!$omp target teams distribute parallel do map(tofrom:ta,u,w,ev,cdiag,diag,csdiag,sdiag)
         do i=1,nelecs
           diag(i)=u(i,nz1)*coef
           sdiag(i)=w(i,nz1)
@@ -244,9 +226,7 @@
           enddo
         enddo
         
-#ifdef ACC
-!$acc end kernels
-#endif
+!$omp end target teams distribute parallel do
 
         call timer_stop(44)
         return
@@ -255,9 +235,7 @@
       if(abs(coef).lt.tau_SIN) then
         ising=3
       else
-#ifdef ACC
-!$acc kernels present(cdiag,diag,csdiag,sdiag,u,w,ta)
-#endif
+!$omp target teams distribute parallel do map(tofrom:cdiag,diag,csdiag,sdiag,u,w,ta)
         do i=1,nelecs
           diag(i)=u(i,nz1)*coef
           sdiag(i)=w(i,nz1)
@@ -269,9 +247,7 @@
           enddo
         enddo
 
-#ifdef ACC
-!$acc end kernels
-#endif
+!$omp end target teams distribute parallel do
         call timer_stop(44)
         return
       endif
@@ -279,4 +255,5 @@
       call timer_stop(44)
 
       return
-      end subroutine gronor_cofac1
+end subroutine gronor_cofac1
+!$omp end declare target

--- a/src/gnome/gronor_environment.F90
+++ b/src/gnome/gronor_environment.F90
@@ -24,12 +24,8 @@ subroutine gronor_environment()
   use inp
   use cidist
 
-  use openacc
   use cuda_functions
-
-#ifdef _OPENMP
   use omp_lib
-#endif
 
   implicit none
 
@@ -217,24 +213,13 @@ subroutine gronor_environment()
   memfre=0
   memtot=0
 
-#ifdef _OPENACC
-#ifdef GPUAMD
-  numdev=acc_get_num_devices(ACC_DEVICE_AMD)
+  numdev=omp_get_num_devices()
   if(numdev.gt.1) then
     if(machine.ne.'Juwels      ') then
       mydev=mod(me,numdev)
-      call acc_set_device_num(mydev,ACC_DEVICE_AMD)
+      call omp_set_default_device(mydev)
     endif
-#else
-    numdev=acc_get_num_devices(ACC_DEVICE_NVIDIA)
-    if(numdev.gt.1) then
-      if(machine.ne.'Juwels      ') then
-        mydev=mod(me,numdev)
-        call acc_set_device_num(mydev,ACC_DEVICE_NVIDIA)
-      endif
-#endif
-    endif
-#endif
+  endif
 
 #ifdef CUDA
     if(numdev.gt.0) then
@@ -600,31 +585,10 @@ subroutine gronor_environment()
     endif
 
     
-#ifdef _OPENACC
     if(numdev.ge.1) then
-#ifdef GPUAMD
-      mydev=acc_get_device_num(ACC_DEVICE_AMD)
-#else
-      mydev=acc_get_device_num(ACC_DEVICE_NVIDIA)
-#endif
+      mydev=omp_get_default_device()
       map2(me+1,7)=mydev
     endif
-#endif
-
-#ifdef OMPTGT
-    if(numdev.ge.1) then
-#ifdef IBM
-      mydev=omp_get_default_device()
-#else
-#ifdef GPUAMD
-      mydev=omp_get_default_device()
-#else
-      mydev=omp_get_device_num()
-#endif
-#endif
-      map2(me+1,7)=mydev
-    endif
-#endif
 
     do i=1,np-1
       map2(i,8)=worker

--- a/src/gnome/gronor_evd.F90
+++ b/src/gnome/gronor_evd.F90
@@ -19,6 +19,7 @@
 !! @date    2025
 !!
 
+!$omp declare target
 subroutine gronor_evd(a,diag,sdiag)
 
   !> Routine that provides all possible calls to Eigensolver library routines
@@ -60,7 +61,6 @@ subroutine gronor_evd(a,diag,sdiag)
 
 #ifdef MKL
   use mkl_solver
-#endif
 
   ! variable declarations
 
@@ -71,7 +71,6 @@ subroutine gronor_evd(a,diag,sdiag)
   external :: tred2,tql2
 #ifdef MKL
   external :: dsyevd
-#endif
 
   integer :: i,j
   integer :: ierr
@@ -80,24 +79,18 @@ subroutine gronor_evd(a,diag,sdiag)
 
   if(iamacc.eq.1) then
      if(levcpu) then
-#ifdef ACC
-!$acc update host (a)
-#endif
+!$omp target update from(a)
       do i=1,nelecs
         sdiag(i)=0.0d0
       enddo
 
     endif
-#ifdef ACC
-!$acc kernels present(sdiag)
-#endif
+!$omp target teams distribute parallel do map(tofrom:sdiag)
 
       do i=1,nelecs
         sdiag(i)=0.0d0
       enddo
-#ifdef ACC
-!$acc end kernels
-#endif
+!$omp end target teams distribute parallel do
 
    else
 
@@ -131,10 +124,9 @@ subroutine gronor_evd(a,diag,sdiag)
 #endif 
 
   if(iamacc.eq.1.and.levcpu) then
-#ifdef ACC
-!$acc update device (diag)
-#endif
+!$omp target update to(diag)
   endif
 
   return
 end subroutine gronor_evd
+!$omp end declare target

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -20,6 +20,7 @@
 !!
 
 
+!$omp declare target
 subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   use mpi
@@ -158,7 +159,6 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
 
   if(iamacc.gt.0) then
 
-!$acc data copyin(va,vb)
     
     !  Calculations of the overlap matrices
 
@@ -246,7 +246,6 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
       call timer_stop(22)
     endif
 
-!$acc end data
 
   else
 ! error! not in acc
@@ -254,3 +253,4 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
 
   return
 end subroutine gronor_gnome
+!$omp end declare target

--- a/src/gnome/gronor_gnone.F90
+++ b/src/gnome/gronor_gnone.F90
@@ -27,6 +27,7 @@
 !!
 
 
+!$omp declare target
 subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
   use cidist
   use gnome_parameters
@@ -59,11 +60,10 @@ subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
   ielem=0
   jkoff=0
 
-!$acc kernels present(t,v,dqm,diag,bdiag,bsdiag,csdiag,ta,aaa,ndxtv)
+!$omp target teams distribute parallel do map(tofrom:t,v,dqm,diag,bdiag,bsdiag,csdiag,ta,aaa,ndxtv)
   if(ising.eq.0) then
-!$acc loop reduction(+:tsum,vsum,dsum1,dsum2,dsum3, &
-!$acc& qsum1,qsum2,qsum3,qsum4,qsum5,qsum6) private(tsj,vsj, &
-!$acc& dsj1,dsj2,dsj3,qsj1,qsj2,qsj3,qsj4,qsj5,qsj6,abjk,j,k,nn)
+!& qsum1,qsum2,qsum3,qsum4,qsum5,qsum6) private(tsj,vsj, &
+!& dsj1,dsj2,dsj3,qsj1,qsj2,qsj3,qsj4,qsj5,qsj6,abjk,j,k,nn)
     do j=1,nbas
       nn=ndxtv(j)
       tsj=0.0d0
@@ -107,7 +107,6 @@ subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
       qsum6=qsum6+qsj6
     enddo
   else
-!$acc loop reduction(+:tsum,vsum,dsum1,dsum2,dsum3,qsum1,qsum2,qsum3,qsum4,qsum5,qsum6)
     do j=1,nbas
       nn=ndxtv(j)
       tsj=0.0d0
@@ -151,7 +150,7 @@ subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
       qsum6=qsum6+qsj6
     enddo
   endif
-!$acc end kernels
+!$omp end target teams distribute parallel do
   potnuc1=potnuc*deta
   e1=tsum+vsum+potnuc1
   mpoles(1)=dsum1
@@ -187,3 +186,4 @@ subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
   endif
   return
 end subroutine gronor_gnone
+!$omp end declare target

--- a/src/gnome/gronor_gntwo.F90
+++ b/src/gnome/gronor_gntwo.F90
@@ -28,6 +28,7 @@
 !! </table>
 !!
 
+!$omp declare target
 subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
   use mpi
@@ -37,7 +38,6 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
   use gnome_integrals
   use iso_c_binding, only : c_loc, c_ptr
 
-  use openacc
   use cuda_functions
 
   implicit none
@@ -88,22 +88,22 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
   tsn=0.0d0
   fourdet=4.0d0*deta
 
-!$acc kernels present(aat,aaa,tt,ta,sm)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm)
   do i=1,nbas
     do k=1,nbas
       tt(i,k)=ta(k,i)
       aat(i,k)=aaa(k,i)
     enddo
   enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
-!$acc kernels present(aat,aaa,tt,ta,sm)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm)
   do i=1,nbas
     do k=1,nbas
       sm(k,i)=aat(k,i)+aaa(k,i)+tt(k,i)+ta(k,i)
     enddo
   enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   call timer_stop(30)
 
@@ -116,7 +116,7 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
     tst=ts
     kl=nbas*(nbas+1)/2
 
-!$acc kernels present(aat,aaa,tt,ta,sm,g,lab,ndx) copyin(kl,intndx,jntndx)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) copyin(kl,intndx,jntndx)
     do ii=intndx,jntndx
       do jj=ii,kl
         intg=ndx(ii)+jj
@@ -129,13 +129,13 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
             -aaa(l,i)*aat(n,k)-ta(l,i)*tt(n,k))
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
 !!! 可选改动。上面的代码实际上外层循环就已经占满所有 sm。
-! !$acc parallel loop gang vector collapse(2) &
-! !$acc   reduction(+:tst)                    &
-! !$acc   present(aat,aaa,tt,ta,sm,g,lab,ndx) &
-! !$acc   copyin(kl,intndx,jntndx)
+! !$omp target teams distribute parallel do gang vector collapse(2) &
+! !   reduction(+:tst)                    &
+! !   map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) &
+! !   copyin(kl,intndx,jntndx)
 !     do ii=intndx,jntndx
 !       do jj=intndx,kl
 !         if (jj < ii) cycle
@@ -149,7 +149,7 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 !             -aaa(l,i)*aat(n,k)-ta(l,i)*tt(n,k))
 !       enddo
 !     enddo
-! !$acc end parallel
+! ! end parallel
 
     ts=tst
 
@@ -162,12 +162,12 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
     diagmax=0.0d0
     bdiagmax=0.0d0
     
-!$acc kernels present(diag,bdiag,bsdiag,csdiag)
+!$omp target teams distribute parallel do map(tofrom:diag,bdiag,bsdiag,csdiag)
     do k=1,nbas
       diagmax=max(diagmax,abs(diag(k)))
       bdiagmax=max(bdiagmax,abs(bdiag(k)))
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     ldiag=diagmax.gt.1.0e-16
     lbdiag=bdiagmax.gt.1.0e-16
@@ -177,8 +177,8 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
     
     if(ldiag.and.lbdiag) then
 
-!$acc kernels present(aat,aaa,tt,ta,sm,g,lab,ndx) &
-!$acc& present(diag,bdiag,bsdiag,csdiag) copyin(kl,intndx,jntndx)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) &
+!& map(tofrom:diag,bdiag,bsdiag,csdiag) copyin(kl,intndx,jntndx)
     do ii=intndx,jntndx
       do jj=ii,kl
         intg=ndx(ii)+jj
@@ -210,11 +210,11 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
             -bal*(aaa(l,i)*aak+aaa(l,k)*aai)-bbl*(ta(l,i)*abk+ta(l,k)*abi))
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     elseif(.not.ldiag .and. lbdiag) then
 
-!$acc update host(aat,aaa,tt,ta,sm,g,lab,ndx,diag,bdiag,bsdiag,csdiag)
+!$omp target update from(aat,aaa,tt,ta,sm,g,lab,ndx,diag,bdiag,bsdiag,csdiag)
     do ii=intndx,jntndx
       do jj=ii,kl
         intg=ndx(ii)+jj
@@ -243,8 +243,8 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
     elseif(ldiag .and. .not. lbdiag) then
 
-!$acc kernels present(aat,aaa,tt,ta,sm,g,lab,ndx) &
-!$acc& present(diag,bdiag,bsdiag,csdiag) copyin(kl,intndx,jntndx)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) &
+!& map(tofrom:diag,bdiag,bsdiag,csdiag) copyin(kl,intndx,jntndx)
     do ii=intndx,jntndx
       do jj=ii,kl
         intg=ndx(ii)+jj
@@ -270,7 +270,7 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
             -bak*(aat(n,i)*aaj+aat(l,i)*aal)-bal*(aaa(l,i)*aak+aaa(l,k)*aai))
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     endif
     
@@ -294,6 +294,7 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
   return
 end subroutine gronor_gntwo
+!$omp end declare target
 
 subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
@@ -305,7 +306,6 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
   use iso_c_binding, only : c_loc, c_ptr
 
 #ifdef _OPENACC
-  use openacc
 #ifdef CUDA
   use cuda_functions
 #endif
@@ -362,22 +362,22 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
   tsn=0.0d0
   fourdet=4.0d0*deta
 
-!$acc kernels present(aat,aaa,tt,ta,sm)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm)
   do i=1,nbas
     do k=1,nbas
       tt(i,k)=ta(k,i)
       aat(i,k)=aaa(k,i)
     enddo
   enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
-!$acc kernels present(aat,aaa,tt,ta,sm)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm)
   do i=1,nbas
     do k=1,nbas
       sm(k,i)=aat(k,i)+aaa(k,i)+tt(k,i)+ta(k,i)
     enddo
   enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   call timer_stop(30)
 
@@ -391,7 +391,7 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
     kl=nbas*(nbas+1)/2
     intg=0
 
-!$acc kernels present(aat,aaa,tt,ta,sm,g,lab,ndx) copyin(intg,nbas)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) copyin(intg,nbas)
     do k=1,nbas
       do i=1,k
         tsn=0.0d0
@@ -410,7 +410,7 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
         tst=tst+tsn
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     ts=tst
 
@@ -423,12 +423,12 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
     diagmax=0.0d0
     bdiagmax=0.0d0
     
-!$acc kernels present(diag,bdiag,bsdiag,csdiag)
+!$omp target teams distribute parallel do map(tofrom:diag,bdiag,bsdiag,csdiag)
     do k=1,nbas
       diagmax=max(diagmax,abs(diag(k)))
       bdiagmax=max(bdiagmax,abs(bdiag(k)))
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     ldiag=diagmax.gt.1.0e-16
     lbdiag=bdiagmax.gt.1.0e-16
@@ -439,8 +439,8 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
 
     if(ldiag.and.lbdiag) then
 
-!$acc kernels present(aat,aaa,tt,ta,sm,g,lab,ndx) present(diag,bdiag,bsdiag,csdiag) &
-!$acc& copyin(intg,kl,intndx,jntndx)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) map(tofrom:diag,bdiag,bsdiag,csdiag) &
+!& copyin(intg,kl,intndx,jntndx)
     do k=1,nbas
       aak=diag(k)
       abk=bdiag(k)
@@ -481,12 +481,12 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
         e2t=e2t+e2n
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   elseif(.not.ldiag .and. lbdiag) then
     
-!$acc kernels present(aat,aaa,tt,ta,sm,g,lab,ndx) present(diag,bdiag,bsdiag,csdiag) &
-!$acc& copyin(intg,kl,intndx,jntndx)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) map(tofrom:diag,bdiag,bsdiag,csdiag) &
+!& copyin(intg,kl,intndx,jntndx)
     do k=1,nbas
       abk=bdiag(k)
       bak=csdiag(k)
@@ -521,12 +521,12 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
         e2t=e2t+e2n
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   elseif(ldiag .and. .not. lbdiag) then
     
-!$acc kernels present(aat,aaa,tt,ta,sm,g,lab,ndx) present(diag,bdiag,bsdiag,csdiag) &
-!$acc& copyin(intg,kl,intndx,jntndx)
+!$omp target teams distribute parallel do map(tofrom:aat,aaa,tt,ta,sm,g,lab,ndx) map(tofrom:diag,bdiag,bsdiag,csdiag) &
+!& copyin(intg,kl,intndx,jntndx)
     do k=1,nbas
       aak=diag(k)
       bak=csdiag(k)
@@ -561,7 +561,7 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
         e2t=e2t+e2n
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     endif
 

--- a/src/gnome/gronor_main.F90
+++ b/src/gnome/gronor_main.F90
@@ -27,6 +27,7 @@
 #include "gronor_compile_time.fh"
 #include "gronor_commit_hash.fh"
 
+!$omp declare target
 subroutine gronor_main()
 
   !>    Initialization of the calculation
@@ -63,13 +64,8 @@ subroutine gronor_main()
   use gnome_solvers
 #ifdef _OPENMP
   use omp_lib
-#endif
   !      use iso_c_binding, only : c_loc, c_ptr
 
-#ifdef _OPENACC
-  use openacc
-  !     use cuda_functions
-#endif
   
   implicit none
 
@@ -135,11 +131,9 @@ subroutine gronor_main()
 
 #ifdef USE_POSIXF
   integer*4 len4,ierr4
-#endif
 
 #ifdef _OPENACC
   type(c_ptr) :: cpfre, cptot
-#endif
 
   call timer_init()
 
@@ -167,7 +161,6 @@ subroutine gronor_main()
     call getenv("LMOD_FAMILY_COMPILER_VERSION",lmodcompv)
     call getenv("LMOD_FAMILY_MPI",lmodmpi)
     call getenv("LMOD_FAMILY_MPI_VERSION",lmodmpiv)
-#endif
 
     n=index(host,':')
     l2=len(trim(host))
@@ -344,11 +337,9 @@ subroutine gronor_main()
     prec='S'
 #else
     prec='D'
-#endif
 
 #ifdef _OPENACC
     naccel=0
-#endif
 
     !     Default print flag set to medium (20)
 
@@ -469,15 +460,11 @@ subroutine gronor_main()
     architecture='CPU:OpenMP'
 #else
     architecture='CPU'
-#endif
     compiler=' '
-#ifdef ACC
 #ifdef GPUAMD
     write(architecture,'(a)') "AMD-GPU:OpenACC"
 #else
     write(architecture,'(a)') "NVIDIA-GPU:OpenACC"
-#endif
-#endif
     
     onlabel='    '
     if(machine.ne.'            ') onlabel=' on '
@@ -526,13 +513,11 @@ subroutine gronor_main()
 602   format(' AMD Accelerator', &
           t60,'Available memory on device',t90,f24.3,' GB',/, &
           t60,'Total memory on device',t90,f24.3,' GB')
-#endif
 #ifdef GPUNVIDIA
       write(lfnout,602) dble(memfre)/dble(1073741824),dble(memtot)/dble(1073741824)
 602   format(' NVIDIA Accelerator', &
           t60,'Available memory on device',t90,f24.3,' GB',/, &
           t60,'Total memory on device',t90,f24.3,' GB')
-#endif
     endif
     if(ipr.gt.0) then
         write(lfnout,655) trim(compiletime),trim(architecture)
@@ -921,7 +906,7 @@ subroutine gronor_main()
 
   !     On the JFZ Juwels Booster the slurm implementation sets the
   !     device on each ranks based on best affinity. As a result
-  !     numdev from acc_get_num_devices returns 1 as each rank
+  !     numdev from omp_get_num_devices returns 1 as each rank
   !     is already associated with the clostest gpu. To get the
   !     correct map2 entries, the ngpus is set to 4 and nummps
   !     multiplied by ngpus.
@@ -1390,17 +1375,12 @@ subroutine gronor_main()
 
     !     On the JFZ Juwels Booster the slurm implementation sets the
     !     device on each ranks based on best affinity. As a result
-    !     no acc_set_device_num should be executed here.
+    !     no omp_set_default_device should be executed here.
 
-#ifdef _OPENACC
     if(numdev.gt.1) then
       mydev=map2(me+1,7)
       if(mydev.ge.0) then
-#ifdef GPUAMD
-        call acc_set_device_num(mydev,ACC_DEVICE_AMD)
-#else
-        call acc_set_device_num(mydev,ACC_DEVICE_NVIDIA)
-#endif
+        call omp_set_default_device(mydev)
         cpfre=c_loc(memfre)
         cptot=c_loc(memtot)
         !     istat=cudaMemGetInfo(cpfre,cptot)
@@ -1415,7 +1395,6 @@ subroutine gronor_main()
         iamacc=0
       endif
     endif
-#endif
 
   !  call gronor_solver_create_handle()
     !  Only accelerated ranks need to define cusolver handles
@@ -1424,7 +1403,6 @@ subroutine gronor_main()
 #ifdef MKL
   if(inslvr.lt.0) inslvr=SOLVER_MKL
   if(jnslvr.lt.0) jnslvr=SOLVER_MKL
-#endif
 
   if(inslvr.lt.0) inslvr=SOLVER_EISPACK
   if(jnslvr.lt.0) jnslvr=SOLVER_EISPACK
@@ -1909,7 +1887,6 @@ subroutine gronor_main()
     rint=dble(4*int2)*1.073741824d-9
 #else
     rint=dble(8*int2)*1.073741824d-9
-#endif
     rndx=(dble(mlab*4)+dble(mlab*4))*1.073741824d-09
     rlst=dble(2*8*numdet)*1.073741824d-9
     igb=1
@@ -1968,7 +1945,6 @@ subroutine gronor_main()
 #else
     write(lfnout,640)
 640 format(/,' Integrals are used in double precision')
-#endif
   endif
   if(me.eq.mstr) flush(lfnout)
 
@@ -1990,7 +1966,6 @@ subroutine gronor_main()
 #else
     write(lfndbg,'(a,1x,a,1x,a,11i5)') date(1:8),time(1:8), &
         ' NVIDIA ',numdev,mydev,iamacc,nummps,numgpu,(map2(me+1,i),i=1,5)
-#endif
     flush(lfndbg)
   endif
 
@@ -2058,7 +2033,6 @@ subroutine gronor_main()
           flush(lfndbg)
         endif
 
-!$acc data copyin(g,lab,ndx,t,v,dqm,ndxtv,s)
         if(idbg.gt.0) then
           call swatch(date,time)
           write(lfndbg,'(a,1x,a,1x,a)') date(1:8),time(1:8),' Calling GronOR_worker'
@@ -2073,7 +2047,6 @@ subroutine gronor_main()
           if(role.eq.manager) call gronor_manager()
           if(role.eq.idle) call gronor_idle()
         endif
-!$acc end data
 
       elseif(ntask.ne.0) then
         call gronor_memory_usage()
@@ -2376,10 +2349,10 @@ subroutine gronor_main()
 987 format('Unable to open vects file ',a)
 988 format('Unable to open civec file ',a)
 end subroutine gronor_main
+!$omp end declare target
 
 #ifdef IBM
 integer function getcpucount()
   getcpucount=0
   return
 end function getcpucount
-#endif

--- a/src/gnome/gronor_moover.F90
+++ b/src/gnome/gronor_moover.F90
@@ -19,6 +19,7 @@
 !! @date    2016
 !!
 
+!$omp declare target
 subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 
   use mpi
@@ -61,7 +62,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
   
   ! Calculation of the overlap matrix ta from va, vb and s
 
-!$acc kernels present(ta,tb,s,vb)
+!$omp target teams distribute parallel do map(tofrom:ta,tb,s,vb)
   do iv=1,nvecb
     do ib=1,nbas
       tb(ib,iv)=0.0d0
@@ -85,12 +86,12 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
       ta(ie,le)=0.0d0
     enddo
   enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   if(nalfa.ne.0) then
 
 
-!$acc kernels present(va,tb)
+!$omp target teams distribute parallel do map(tofrom:va,tb)
     do ke=1,nalfa
       do ie=1,nalfa
         sum=0.0d0
@@ -100,7 +101,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
         ta(ie,ke)=sum
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   endif
 
@@ -109,10 +110,9 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
   if(ntcla.ne.0.and.ntclb.ne.0) then
 
 
-!$acc parallel loop present(ta) private(ii,kk)
+!$omp target teams distribute parallel do map(tofrom:ta) private(ii,kk)
     do i=1,ntcla
       ii=i+nalfa
-!$acc loop vector
       do k=1,ntclb
         kk=k+nalfa
         ta(ii,kk)=ta(i,k)
@@ -129,7 +129,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 
     if(ntclb.gt.0) then
 
-!$acc kernels present(va,ta,tb)
+!$omp target teams distribute parallel do map(tofrom:va,ta,tb)
       do k=1,ntclb
         kk=k+nalfa
         do i=m1,nveca
@@ -140,13 +140,13 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
           ta(i+ntcla,kk)=sum
         enddo
       enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     endif
 
     if(nvecb.gt.nalfa) then
 
-!$acc kernels present(va,ta,tb)
+!$omp target teams distribute parallel do map(tofrom:va,ta,tb)
       do k=nalfa+1,nvecb
         kk=k+ntclb
         do i=m1,nveca
@@ -157,7 +157,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
           ta(i+ntcla,kk)=sum
         enddo
       enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
     endif
 
@@ -165,7 +165,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 
   if(nvecb.ne.nalfa.and.ntcla.ne.0) then
 
-!$acc kernels present(va,ta,tb)
+!$omp target teams distribute parallel do map(tofrom:va,ta,tb)
     do i=1,ntcla
       do k=m1,nvecb
         sum=0.0d0
@@ -175,14 +175,14 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
         ta(i+nalfa,k+ntclb)=sum
       enddo
     enddo
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   endif
 
   !  There are problems with svd if many off diagonal elements occur
   !  of size 1.0 e-13. therefore all elements < 1.0 e-10 are set to zero
 
-!$acc kernels present(ta)
+!$omp target teams distribute parallel do map(tofrom:ta)
 
   do i1=1,nelecs
     do i2=1,nelecs
@@ -191,8 +191,9 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
     enddo
   enddo
 
-!$acc end kernels
+!$omp end target teams distribute parallel do
 
   return
 end subroutine gronor_moover
+!$omp end declare target
 

--- a/src/gnome/gronor_svd.F90
+++ b/src/gnome/gronor_svd.F90
@@ -18,6 +18,7 @@
 !! @date    2025
 !!
 
+!$omp declare target
 subroutine gronor_svd(a,ev,u,w,sdiag,wt)
 
   !> Routine that provides all possible calls to Singular Value Decomposition library routines
@@ -61,7 +62,6 @@ subroutine gronor_svd(a,ev,u,w,sdiag,wt)
 
 #ifdef MKL
   use mkl_solver
-#endif
   
   ! variable declarations
 
@@ -80,9 +80,7 @@ subroutine gronor_svd(a,ev,u,w,sdiag,wt)
   lwork4=int(len_work_dbl,kind=4)
   
   if(iamacc.eq.1.and.lsvcpu) then
-#ifdef ACC
-!$acc update host (a)
-#endif
+!$omp target update from(a)
   endif
 
   ! ========== EISPACK =========
@@ -118,27 +116,22 @@ subroutine gronor_svd(a,ev,u,w,sdiag,wt)
 
     elseif(iamacc.eq.1) then
 
-#ifdef ACC
-!$acc kernels present(w,wt)
-#endif
+!$omp target teams distribute parallel do map(tofrom:w,wt)
   do i=1,nelecs
     do j=1,nelecs
       w(i,j)=wt(j,i)
     enddo
   enddo
-#ifdef ACC
-!$acc end kernels
-#endif
+!$omp end target teams distribute parallel do
       
     endif
   endif
 
 !! Update device if SVD was performed on the host for accelerated ranks
   if(iamacc.eq.1.and.lsvcpu) then
-#ifdef ACC
-!$acc update device (ev,u,w)
-#endif
+!$omp target update to(ev,u,w)
   endif
 
   return  
 end subroutine gronor_svd
+!$omp end declare target

--- a/src/gnome/gronor_tramat.F90
+++ b/src/gnome/gronor_tramat.F90
@@ -20,6 +20,7 @@
 !!
 
 
+!$omp declare target
 subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
 
   !      This routine mutiplies the input-matrix (a)
@@ -43,12 +44,7 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
 
   m1=nalfa+1
 
-#ifdef ACC
-!$acc kernels present(va,vb,diag,sdiag,ta,taa,w1,w2)
-#endif
-#ifdef ACC
-!$acc loop collapse(2)
-#endif
+!$omp target teams distribute parallel do map(tofrom:va,vb,diag,sdiag,ta,taa,w1,w2)
   do i=1,nelecs
     do j=1,nelecs
       taa(j,i)=ta(j,i)
@@ -61,16 +57,10 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
     do j=1,nbas
       sum=0.0d0
       if(nalfa .ne. 0) then
-#ifdef ACC
-!$acc loop reduction(+:sum)
-#endif
         do k=1,nalfa
           sum=sum+diag(k)*va(k,j)
         enddo
         if(ntcla .ne. 0) then
-#ifdef ACC
-!$acc loop reduction(+:sum)
-#endif
           do k=1,ntcla
             kk=k+nalfa
             sum=sum+diag(kk)*va(k,j)
@@ -78,9 +68,6 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
         endif
       endif
       if(nalfa .ne. nveca) then
-#ifdef ACC
-!$acc loop reduction(+:sum)
-#endif
         do k=m1,nveca
           kk=k+ntcla
           sum=sum+diag(kk)*va(k,j)
@@ -97,23 +84,14 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
   !                first :
   !     calculation of an intermediate array (w)
 
-#ifdef ACC
-!$acc loop collapse(2)
-#endif
   do j=1,nelecs
     do i=1,nbas
       sum=0.0d0
       if(nalfa .ne. 0) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
         do k=1,nalfa
           sum=sum+va(k,i)*taa(k,j)
         enddo
         if(ntcla .ne. 0) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
           do k=1,ntcla
             kk=k+nalfa
             sum=sum+va(k,i)*taa(kk,j)
@@ -121,9 +99,6 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
         endif
       endif
       if(nalfa .ne. nveca) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
         do k=m1,nveca
           kk=k+ntcla
           sum=sum+va(k,i)*taa(kk,j)
@@ -134,9 +109,6 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
   enddo
 
   !     put w in the work-matrix (aa)
-#ifdef ACC
-!$acc loop collapse(2)
-#endif
   do j=1,nelecs
     do i=1,nbas
       taa(i,j)=w2(i,j)
@@ -145,23 +117,14 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
 
   !     calculation of the final matrix aa
 
-#ifdef ACC
-!$acc loop collapse(2)
-#endif
   do i=1,nbas
     do j=1,nbas
       sum=0.0d0
       if(nalfa .ne. 0) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
         do k=1,nalfa
           sum=sum+taa(i,k)*vb(k,j)
         enddo
         if(ntclb .ne. 0) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
           do k=1,ntclb
             kk=k+nalfa
             sum=sum+taa(i,kk)*vb(k,j)
@@ -169,9 +132,6 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
         endif
       endif
       if(nalfa .ne. nvecb) then
-#ifdef ACC
-!$acc loop reduction(+:sum)
-#endif
         do k=m1,nvecb
           kk=k+ntclb
           sum=sum+taa(i,kk)*vb(k,j)
@@ -183,9 +143,6 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
 
   !     put w back in the work-matrix aa
 
-#ifdef ACC
-!$acc loop collapse(2)
-#endif
   do j=1,nbas
     do i=1,nbas
       taa(i,j)=w2(i,j)
@@ -198,16 +155,10 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
     do j=1,nbas
       sum=0.0d0
       if(nalfa .ne. 0) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
         do k=1,nalfa
           sum=sum+sdiag(k)*vb(k,j)
         enddo
         if(ntclb .ne. 0) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
           do k=1,ntclb
             kk=k+nalfa
             sum=sum+sdiag(kk)*vb(k,j)
@@ -215,9 +166,6 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
         endif
       endif
       if(nalfa .ne. nvecb) then
-#ifdef ACC
-!$acc loop seq reduction(+:sum)
-#endif
         do k=m1,nvecb
           kk=k+ntclb
           sum=sum+sdiag(kk)*vb(k,j)
@@ -232,9 +180,8 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
 
   endif
 
-#ifdef ACC
-!$acc end kernels
-#endif
+!$omp end target teams distribute parallel do
   return
 end subroutine gronor_tramat
+!$omp end declare target
 

--- a/src/gnome/gronor_tramat2.F90
+++ b/src/gnome/gronor_tramat2.F90
@@ -19,6 +19,7 @@
 !! @date    2016
 !!
 
+!$omp declare target
 subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
 
   !      Transformation of the  m.o.'s
@@ -41,7 +42,7 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 600 format(/,' Cofactor matrix transform to symmetry functions')
 
 
-!$acc kernels present(va,vb,diag,bdiag,cdiag,bsdiag,csdiag,ta,aaa,w1,w2)
+!$omp target teams distribute parallel do map(tofrom:va,vb,diag,bdiag,cdiag,bsdiag,csdiag,ta,aaa,w1,w2)
 
   do j=1,nbas
     diag(j)=0.0d0
@@ -53,10 +54,8 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
     !     transformation of diag and sdiag
 
     if(nalfa.ne.0) then
-!$acc loop private(sum)
       do j=1,nbas
         sum=0.0d0
-!$acc loop reduction(+:sum)
         do k=1,nalfa
           sum=sum+cdiag(k)*va(k,j)
         enddo
@@ -65,10 +64,8 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
     endif
 
     if(ntcla.ne.0) then
-!$acc loop private(sum)
       do j=1,nbas
         sum=0.0d0
-!$acc loop reduction(+:sum)
         do k=1,ntcla
           kk=k+nalfa
           sum=sum+cdiag(kk)*va(k,j)
@@ -79,10 +76,8 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
     if(nalfa.ne.nveca) then
       m1=nalfa+1
-!$acc loop private(sum)
       do j=1,nbas
         sum=0.0d0
-!$acc loop reduction(+:sum)
         do k=m1,nveca
           kk=k+ntcla
           sum=sum+cdiag(kk)*va(k,j)
@@ -92,10 +87,8 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
     endif
 
     if(nalfa.ne.0) then
-!$acc loop private(sum)
       do j=1,nbas
         sum=0.0d0
-!$acc loop reduction(+:sum)
         do k=1,nalfa
           sum=sum+csdiag(k)*vb(k,j)
         enddo
@@ -104,10 +97,8 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
     endif
 
     if(ntclb.ne.0) then
-!$acc loop private(sum)
       do j=1,nbas
         sum=0.0d0
-!$acc loop reduction(+:sum) private(kk)
         do k=1,ntclb
           kk=k+nalfa
           sum=sum+csdiag(kk)*vb(k,j)
@@ -118,10 +109,8 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
     if(nalfa.ne.nvecb) then
       m1=nalfa+1
-!$acc loop private(sum)
       do j=1,nbas
         sum=0.0d0
-!$acc loop reduction(+:sum) private(kk)
         do k=m1,nvecb
           kk=k+ntclb
           sum=sum+csdiag(kk)*vb(k,j)
@@ -130,7 +119,6 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
       enddo
     endif
 
-!$acc loop
     do j=1,nbas
       csdiag(j)=w1(j)
     enddo
@@ -143,11 +131,9 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
   if(nalfa.ne.0) then
 
-!$acc loop collapse(2) private(sum)
     do i=1,nalfa
       do j=1,nbas
         sum=0.0d0
-!$acc loop reduction(+:sum)
         do k=1,nalfa
           sum=sum+ta(i,k)*vb(k,j)
         enddo
@@ -155,7 +141,6 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
       enddo
     enddo
 
-!$acc loop collapse(2)
     do j=1,nbas
       do i=1,nalfa
         ta(i,j)=w2(i,j)
@@ -171,14 +156,12 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
       do j=1,nbas
         sum=0.0d0
         if(ntclb.ne.0) then
-!$acc loop reduction(+:sum) private(kk)
           do k=1,ntclb
             kk=k+nalfa
             sum=sum+ta(i,kk)*vb(k,j)
           enddo
         endif
         if(nalfa.ne.nvecb) then
-!$acc loop reduction(+:sum) private(kk)
           do k=m1,nvecb
             kk=k+ntclb
             sum=sum+ta(i,kk)*vb(k,j)
@@ -199,11 +182,9 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
   if(nalfa.ne.0) then
 
-!$acc loop collapse(2) private(sum)
     do j=1,nbas
       do i=1,nbas
         sum=0.0
-!$acc loop seq reduction(+:sum)
         do k=1,nalfa
           sum=sum+ta(k,j)*va(k,i)
         enddo
@@ -215,19 +196,16 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
   if(nalfa.ne.nelecs) then
 
-!$acc loop collapse(2) private(sum)
     do j=1,nbas
       do i=1,nbas
         sum=0.0d0
         if(ntcla.ne.0) then
-!$acc loop seq reduction(+:sum) private(kk)
           do k=1,ntcla
             kk=k+nalfa
             sum=sum+ta(kk,j)*va(k,i)
           enddo
         endif
         if(nalfa.ne.nveca) then
-!$acc loop seq reduction(+:sum) private(kk)
           do k=m1,nveca
             kk=k+ntcla
             sum=sum+ta(kk,j)*va(k,i)
@@ -237,7 +215,6 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
       enddo
     enddo
 
-!$acc loop collapse(2)
     do j=1,nbas
       do i=1,nbas
         ta(i,j)=w2(i,j)
@@ -246,7 +223,6 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
   else
 
-!$acc loop collapse(2)
     do j=1,nbas
       do i=1,nbas
         ta(i,j)=0.0d0
@@ -255,10 +231,10 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
   endif
 
-!$acc end kernels
+!$omp end target teams distribute parallel do
   
   if(idbg.gt.90) then
-!$acc update host(aaa,ta,diag,bdiag,bsdiag,csdiag,sdiag)
+!$omp target update from(aaa,ta,diag,bdiag,bsdiag,csdiag,sdiag)
     write(lfndbg,1601) nbas,nelecs
 1601 format(//,' diag:',3i6,/)
     do i=1,nbas
@@ -289,3 +265,4 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
   return
 end subroutine gronor_tramat2
+!$omp end declare target

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -16,6 +16,7 @@
 !!    @brief Driver for calculation Hamiltonian matrix elements on worker ranks
 !!    @author T. P. Straatsma (ORNL)
 
+!$omp declare target
 subroutine gronor_worker()
 
   use mpi
@@ -27,7 +28,6 @@ subroutine gronor_worker()
   use gnome_solvers
 #ifdef _OPENMP
   use omp_lib
-#endif
 
   implicit none
 
@@ -136,9 +136,6 @@ subroutine gronor_worker()
   allocate(aat(mbasel,max(mbasel,nveca)))
   allocate(sm(mbasel,max(mbasel,nveca)))
 
-#ifdef ACC
-!$acc data
-#endif
 
   if(idbg.gt.50 .and. thread_id==0) then
     call swatch(date,time)
@@ -157,9 +154,6 @@ subroutine gronor_worker()
 
   call gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
-#ifdef ACC
-!$acc end data
-#endif
 
   call gronor_solver_finalize()
 
@@ -187,7 +181,6 @@ subroutine gronor_worker()
   deallocate(sm)
 
 !$omp end parallel
-#endif
 
   call gronor_update_device_info()
 
@@ -198,6 +191,7 @@ subroutine gronor_worker()
   
   return
 end subroutine gronor_worker
+!$omp end declare target
 
 subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 


### PR DESCRIPTION
## Summary
- replace OpenACC device setup with OpenMP runtime calls
- convert legacy OpenACC pragmas to OpenMP `target teams distribute parallel do`
- switch accelerator updates to `omp target update`

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_688ecfa9e71c832aa1c5d85115f44c5f