### PR TITLE
Make solver workspace lengths threadprivate

### DIFF
--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -258,6 +258,7 @@ module gnome_data
 
 !  real (kind=8), allocatable :: work(:)
   integer (kind=8) :: len_work_dbl,len_work2_dbl,len_work_int,info
+!$omp threadprivate(len_work_dbl,len_work2_dbl,len_work_int,info)
 
   real (kind=8) :: buffer(17)
 !$omp threadprivate(buffer,e2buff,e2summ)


### PR DESCRIPTION
## Summary
- Ensure `len_work_dbl`, `len_work2_dbl`, `len_work_int`, and `info` are `threadprivate` in `gnome_data`

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee564d4e8832a8cced61a93582c63