### PR TITLE
Mark solver flags threadprivate

### DIFF
--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -182,6 +182,7 @@ module gnome_parameters
   logical :: odbg,odupl,oterm,otreq,otimeout
   logical :: corres
   logical :: lsvcpu,levcpu,lsvtrns
+!$omp threadprivate(lsvcpu,levcpu,lsvtrns)
 
   character (len=1) :: prec
   character (len=128) :: mebfroot,combas


### PR DESCRIPTION
## Summary
- mark lsvcpu, levcpu and lsvtrns as threadprivate in gnome_parameters

## Testing
- `cmake -DOMP=ON ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `sudo apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ee8198fd4832a85f62a3daaf517a2