### PR TITLE
Make solver workspaces threadprivate

### DIFF
--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -368,6 +368,7 @@ module gnome_solvers
 
   integer (kind=8) :: lwork,liwork,ndimm,mdimm,ndim8,lwork8,liwork8
   integer (kind=4) :: mdim,ndim,ndim4,lwork4,liwork4
+!$omp threadprivate(ndimm,mdimm,lwork,liwork,ndim8,lwork8,liwork8,mdim,ndim,ndim4,lwork4,liwork4)
 
   real(kind=8), allocatable :: work(:)
   integer(kind=8), allocatable :: iwork(:)


### PR DESCRIPTION
## Summary
- Ensure solver dimension and workspace parameters are thread-local by marking them `threadprivate`.

## Testing
- `ctest` (fails: No test configuration file found)


------
https://chatgpt.com/codex/tasks/task_e_688eeaa3169c832aa6182a33fb97dc1c