### PR TITLE
Make deta threadprivate

### DIFF
--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -254,7 +254,7 @@ module gnome_data
   integer :: ising
 !$omp threadprivate(ntesta,ntestb,ijend)
 !$omp threadprivate(nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb,n1bas,nstdim,mbasel,nelecs)
-!$omp threadprivate(e1,e2,e2c,etot,etotb,fac,fctr,mpoles,e1tot,e2tot,sstot,hh,ss,ttest,ising)
+!$omp threadprivate(e1,e2,e2c,etot,etotb,deta,fac,fctr,mpoles,e1tot,e2tot,sstot,hh,ss,ttest,ising)
 !$omp threadprivate(ioccup,vec,vtemp,ioccn)
 
 !  real (kind=8), allocatable :: work(:)


### PR DESCRIPTION
## Summary
- ensure `deta` is threadprivate in `gnome_data`
- confirm routines using `deta` continue to access it from the module

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688eedefc154832ab0432926638bcdfb