### PR TITLE
Expand OpenACC data regions for worker and gnome

### DIFF
--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -158,7 +158,8 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
 
   if(iamacc.gt.0) then
 
-!$acc data copyin(va,vb)
+!$acc data present(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag, &
+!$acc& ioccup,vec,vtemp,ioccn)
     
     !  Calculations of the overlap matrices
 

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -148,7 +148,8 @@ subroutine gronor_worker()
   allocate(vecb(mbasel))
 
 #ifdef ACC
-!$acc data
+!$acc data create(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag, &
+!$acc& ioccup,vec,vtemp,ioccn)
 #endif
 
   if(idbg.gt.50 .and. thread_id==0) then
@@ -167,10 +168,6 @@ subroutine gronor_worker()
 
 
   call gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
-
-#ifdef ACC
-!$acc end data
-#endif
 
   call gronor_solver_finalize()
 
@@ -202,6 +199,10 @@ subroutine gronor_worker()
   deallocate(veca)
   deallocate(vecb)
   deallocate(ioccn)
+
+#ifdef ACC
+!$acc end data
+#endif
 
 !$omp end parallel
 #endif


### PR DESCRIPTION
## Summary
- expand worker OpenACC data region to explicitly create all solver arrays and keep it open through deallocation
- rely on worker data region in gnome by marking arrays as present instead of copying them in

## Testing
- `ctest` *(fails: No test configuration file found)*
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_688f1d8a28d8832abcbc54ab6cc30526