### PR TITLE
Preserve configured thread count in master

### DIFF
--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -74,7 +74,12 @@ subroutine gronor_master()
   allocate(pnrb(nbase,nbase))
   allocate(fday(nbase,nbase))
 #ifdef _OPENMP
-  num_threads = omp_get_max_threads()
+  if (num_threads > omp_get_max_threads()) then
+    write(lfnout,*) 'Warning: Requested num_threads', num_threads, &
+         & ' exceeds available threads ', omp_get_max_threads()
+    flush(lfnout)
+    num_threads = omp_get_max_threads()
+  endif
 #else
   num_threads = 1
 #endif


### PR DESCRIPTION
## Summary
- Respect externally configured thread count by removing hard reset to `omp_get_max_threads` in `gronor_master`.
- Warn and cap when requested threads exceed runtime maximum.

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get update` *(fails: repository ... InRelease is not signed; 403 Forbidden)*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_688f25db70c8832aaa6d33707cb5d806