### PR TITLE
Add thread-private open-shell data structures

### DIFF
--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -209,6 +209,10 @@ module gnome_data
 
   integer :: nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb
 
+  integer :: ntcl(2), ntop(2), nclose(2), nopen(2), nelec(2)
+  integer :: nact(2), ninact(2)
+  integer(kind=1), allocatable :: iocopen(:,:)
+
   character (len=80) :: text,name(2),namint(2)
   real (kind=8) :: potnuc,zNucTot
   character (len=4), allocatable :: centn(:)
@@ -258,7 +262,8 @@ module gnome_data
 !$omp threadprivate(ntesta,ntestb,ijend)
 !$omp threadprivate(nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb,n1bas,nstdim,mbasel,nelecs)
 !$omp threadprivate(e1,e2,e2c,etot,etotb,deta,fac,fctr,mpoles,e1tot,e2tot,sstot,hh,ss,ttest,ising)
-!$omp threadprivate(ioccup,vec,vtemp,ioccn)
+!$omp threadprivate(ntcl,ntop,nclose,nopen,nelec,nact,ninact,iocopen)
+!$omp threadprivate(ioccup,vec,vtemp,ioccn,iocopen)
 
 !  real (kind=8), allocatable :: work(:)
   integer (kind=8) :: len_work_dbl,len_work2_dbl,len_work_int,info

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -141,6 +141,7 @@ subroutine gronor_worker()
   allocate(aat(mbasel,max(mbasel,nveca)))
   allocate(sm(mbasel,max(mbasel,nveca)))
   allocate(ioccup(mnact,2))
+  allocate(iocopen(mnact,2))
   allocate(vec(mvec,mbasel,2))
   allocate(vtemp(mvec,mbasel,2))
   allocate(ioccn(nsrep,2))
@@ -149,7 +150,7 @@ subroutine gronor_worker()
 
 #ifdef ACC
 !$acc data create(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag, &
-!$acc& ioccup,vec,vtemp,ioccn)
+!$acc& ioccup,iocopen,vec,vtemp,ioccn)
 #endif
 
   if(idbg.gt.50 .and. thread_id==0) then
@@ -194,6 +195,7 @@ subroutine gronor_worker()
   deallocate(aat)
   deallocate(sm)
   deallocate(ioccup)
+  deallocate(iocopen)
   deallocate(vec)
   deallocate(vtemp)
   deallocate(veca)


### PR DESCRIPTION
## Summary
- track closed/open-shell and electron counts with new thread-private arrays in `gnome_data`
- allocate and free `iocopen` alongside other per-thread buffers in `gronor_worker`

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_688f41a8f7fc832a8d720d3f1bc1d8ec