### PR TITLE
Refactor gronor_transvc argument handling

### DIFF
--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -87,7 +87,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     endif
 
     call timer_start(11)
-    call gronor_transvc(lfndbg,idet,ntcl,ntop,nclose,nopen,iocopen)
+    call gronor_transvc(lfndbg, idet)
     call timer_stop(11)
 
     call timer_start(12)

--- a/src/gnome/gronor_transvc.F90
+++ b/src/gnome/gronor_transvc.F90
@@ -32,7 +32,7 @@
 !! @date    2016
 !!
 
-subroutine gronor_transvc(lfndbg,idet,ntcl,ntop,nclose,nopen,iocopen)
+subroutine gronor_transvc(lfndbg, idet)
   
   use cidist
   use gnome_data
@@ -40,9 +40,7 @@ subroutine gronor_transvc(lfndbg,idet,ntcl,ntop,nclose,nopen,iocopen)
   
   implicit none
 
-  integer, intent(in) :: lfndbg,idet
-  integer, intent(inout) :: ntcl(:),ntop(:),nclose(:),nopen(:)
-  integer, intent(inout) :: iocopen(:,:)
+  integer, intent(in) :: lfndbg, idet
   integer :: m,n1,iop,ib,iv,k,i,l,im,ls,norbs
   if(idbg.ge.17) write(lfndbg,601)
 601 format(/,' Determinant Irrep  Nclose  Nopen OccActive',/)


### PR DESCRIPTION
## Summary
- Simplify `gronor_transvc` interface to rely on module data for shell occupation arrays
- Update `gronor_gnome` call site to match new routine signature

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f643449dc832a923530ea1c9d170c