### PR TITLE
Access ntcl and ntop through module

### DIFF
--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -95,7 +95,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     call timer_stop(12)
 
     call timer_start(13)
-    call gronor_tranout(lfndbg,idet,ntcl,ntop)
+    call gronor_tranout(lfndbg,idet)
     call timer_stop(13)
 
     if(idbg.ge.20) write(lfndbg,606) idet

--- a/src/gnome/gronor_tranout.F90
+++ b/src/gnome/gronor_tranout.F90
@@ -19,13 +19,12 @@
 !! @date    2016
 !!
 
-subroutine gronor_tranout(lfndbg,idet,ntcl,ntop)
+subroutine gronor_tranout(lfndbg,idet)
   use cidist
   use gnome_parameters
   use gnome_data
   implicit none
   integer, intent(in) :: lfndbg,idet
-  integer, intent(inout) :: ntcl(:),ntop(:)
   integer :: ivc,ntvc,ibas,i
 
   ntvc=ntcl(idet)+ntop(idet)


### PR DESCRIPTION
## Summary
- Simplify gronor_tranout interface by sourcing ntcl and ntop from gnome_data
- Update gronor_gnome to call gronor_tranout with reduced argument list

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `ctest --test-dir build` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_688f672f42b8832aae19441fec6fa4d6