### PR TITLE
Simplify OpenACC data region in gronor_worker

### DIFF
--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -149,8 +149,7 @@ subroutine gronor_worker()
   allocate(vecb(mbasel))
 
 #ifdef ACC
-!$acc data create(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag, &
-!$acc& ioccup,iocopen,vec,vtemp,ioccn)
+!$acc data create(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 #endif
 
   if(idbg.gt.50 .and. thread_id==0) then


### PR DESCRIPTION
## Summary
- remove unused arrays from the OpenACC `data create` directive in `gronor_worker`

## Testing
- `ctest` (fails: No test configuration file found)


------
https://chatgpt.com/codex/tasks/task_e_688f6e6610a8832abbf66da9799596a0