### PR TITLE
Refine OpenACC data region

### DIFF
--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -158,8 +158,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
 
   if(iamacc.gt.0) then
 
-!$acc data present(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag, &
-!$acc& ioccup,vec,vtemp,ioccn)
+!$acc data present(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
     
     !  Calculations of the overlap matrices
 


### PR DESCRIPTION
## Summary
- streamline GNOME OpenACC data region by removing unused arrays
- ensure remaining arrays participate in downstream OpenACC kernels

## Testing
- `cmake -S . -B build -DACC=ON` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `sudo apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f6f356de4832a96dc48429a8933df