### PR TITLE
Expand OpenMP copyin and remove unused bases

### DIFF
--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -171,7 +171,6 @@ module gnome_parameters
   integer :: naccel,nacc0,nacc1,nidle,inpcib,intfil,ncols
   integer :: iday,idipole,itp4,nummps,numgpu,ixpert
   integer :: ins2
-  integer :: ibase0,jbase0,idet0,jdet0
   integer :: ndeti,ndetj,nacti,nactj,inacti,inactj
   real (kind=8) :: tau_MO,tau_CI,tau_CI_off,tau_SIN,thresh,thresh_SIN
   real (kind=8) :: tolsvj,tolevj

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -99,11 +99,6 @@ subroutine gronor_worker()
   nvecb=nveca
   nstdim=max(1,nelecs*nelecs,nbas*(nbas+1)/2)
   mbasel=max(nelecs,nbas)
-
-  ibase0=0
-  jbase0=0
-  idet0=0
-  jdet0=0
   
   icur=0
   jcur=0
@@ -112,7 +107,7 @@ subroutine gronor_worker()
   call omp_set_num_threads(num_threads)
 
 !$omp parallel private(thread_id,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag) &
-!$omp& copyin(oterm,otreq,odupl,itreq,irbuf)
+!$omp& copyin(oterm,otreq,odupl,itreq,irbuf,icur,jcur,nelecs,nveca,nvecb,nstdim,mbasel)
 
   thread_id = omp_get_thread_num()
 


### PR DESCRIPTION
## Summary
- expand OpenMP worker copyin clause to include thread-private dimensions
- remove unused base/determinant variables

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68903aabc94c832a93e33f533241e5e8