### PR TITLE
Place thread ID at end of tbuf buffer

### DIFF
--- a/src/gnome/gronor_manager.F90
+++ b/src/gnome/gronor_manager.F90
@@ -41,7 +41,6 @@ subroutine gronor_manager()
   do i=1,18
     tbuf(i)=0.0d0
   enddo
-  tbuf(1)=0.0d0
 
   numtsk=0
   do i=1,np
@@ -180,13 +179,13 @@ subroutine gronor_manager()
       ncount=18
       mpitag=1
       call MPI_Recv(buffer,ncount,MPI_REAL8,MPI_ANY_SOURCE,mpitag,MPI_COMM_WORLD,status,ierr)
-      tid=int(buffer(1))
+      tid=int(buffer(18))
       iremote=status(MPI_SOURCE)
       do j=1,numwrk
         if(mgrwrk(j,1).eq.iremote) then
           if(mgrwrk(j,2).eq.0) then
             numrcv=numrcv+1
-            do i=2,18
+            do i=1,17
               tbuf(i)=tbuf(i)+buffer(i)
             enddo
             mgrwrk(j,2)=1
@@ -212,12 +211,12 @@ subroutine gronor_manager()
         endif
       enddo
     enddo
-    
+
     call timer_stop(53)
-    
+
     ! Send results buffer to master
     call timer_start(54)
-    tbuf(1)=0.0d0
+    tbuf(18)=0.0d0
     ncount=18
     mpitag=1
     call MPI_iSend(tbuf,ncount,MPI_REAL8,mstr,mpitag,MPI_COMM_WORLD,ireq,ierr)

--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -364,9 +364,9 @@ subroutine gronor_master()
         ncount=18
         mpitag=1
         call MPI_Recv(tbuf,ncount,MPI_REAL8,MPI_ANY_SOURCE,mpitag,MPI_COMM_WORLD,status,ierr)
-        tid=int(tbuf(1))+1
+        tid=int(tbuf(18))+1
         do k=1,17
-          buffer(k)=tbuf(k+1)
+          buffer(k)=tbuf(k)
         enddo
         write(lfnmpi,'("recv from",i0," tid",i0," buf=",17(1x,e16.8))') status(MPI_SOURCE),tid-1,(buffer(k),k=1,17)
         call timer_stop(94)
@@ -823,9 +823,9 @@ subroutine gronor_master()
     ncount=18
     mpitag=1
     call MPI_Recv(tbuf,ncount,MPI_REAL8,MPI_ANY_SOURCE,mpitag,MPI_COMM_WORLD,status,ierr)
-    tid=int(tbuf(1))+1
+    tid=int(tbuf(18))+1
     do k=1,17
-      buffer(k)=tbuf(k+1)
+      buffer(k)=tbuf(k)
     enddo
     write(lfnmpi,'("recv dup from",i0," tid",i0," buf=",17(1x,e16.8))') status(MPI_SOURCE),tid-1,(buffer(k),k=1,17)
     call timer_stop(96)

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -278,9 +278,9 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
   do i=1,18
     tbuf(i)=0.0d0
   enddo
-  tbuf(1)=dble(thread_id)
-  tbuf(17)=dble(len_work_dbl)
-  tbuf(18)=dble(len_work_int)
+  tbuf(16)=dble(len_work_dbl)
+  tbuf(17)=dble(len_work_int)
+  tbuf(18)=dble(thread_id)
 
   write(mpifile,'("mpi_log_rank",i0,"_thread",i0,".log")') me,thread_id
   open(newunit=lfnmpi,file=mpifile,status='replace',action='write',iostat=ierr)
@@ -312,7 +312,7 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
     call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
   endif
   call MPI_Request_free(ireq,ierr)
-  write(lfnmpi,'("send ready len_work_dbl=",i0," len_work_int=",i0)') int(tbuf(17)),int(tbuf(18))
+  write(lfnmpi,'("send ready len_work_dbl=",i0," len_work_int=",i0)') int(tbuf(16)),int(tbuf(17))
   if(idbg.gt.20) then
     call swatch(date,time)
     write(lfndbg,'(a,1x,a,1x,a)') date(1:8),time(1:8),' Head signalled master'
@@ -485,9 +485,9 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
       call timer_start(48)
       !     Send results back to master
       do i=1,17
-        tbuf(i+1)=buffer(i)
+        tbuf(i)=buffer(i)
       enddo
-      tbuf(1)=dble(thread_id)
+      tbuf(18)=dble(thread_id)
       ncount=18
       mpitag=1
       call MPI_iSend(tbuf,ncount,MPI_REAL8,mstr,mpitag,MPI_COMM_WORLD,ireq,ierr)


### PR DESCRIPTION
## Summary
- Keep original tbuf layout and append thread ID at index 18 in worker threads
- Update master to read thread ID from tbuf(18) and treat first 17 entries as payload
- Adjust manager to aggregate and forward buffers with thread ID in the last slot

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_689045f2d070832aa831b62bdd063995