### PR TITLE
Use per-thread MPI tags for task dispatch

### DIFF
--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -743,7 +743,7 @@ subroutine gronor_master()
         ipbuf(3,iremote+1,tid)=ibuf(3)
         ipbuf(4,iremote+1,tid)=ibuf(4)
         ncount=4
-        mpitag=2
+        mpitag=100+tid-1
 
         call MPI_iSend(ipbuf(1,iremote+1,tid),ncount,MPI_INTEGER8, &
             iremote,mpitag,MPI_COMM_WORLD,send_req(iremote+1,tid),ierr)
@@ -1139,7 +1139,7 @@ subroutine gronor_master()
           ipbuf(3,iremote+1,tid)=ibuf(3)
           ipbuf(4,iremote+1,tid)=ibuf(4)
           ncount=4
-          mpitag=2
+          mpitag=100+tid-1
 
           call MPI_iSend(ipbuf(1,iremote+1,tid),ncount,MPI_INTEGER8, &
               iremote,mpitag,MPI_COMM_WORLD,send_req(iremote+1,tid),ierr)
@@ -1246,17 +1246,19 @@ subroutine gronor_master()
     itbuf(4,iremote+1)=-1
 
     ncount=4
-    mpitag=2
+    do tid=1,num_threads
+      mpitag=100+tid-1
 
-    call MPI_iSend(itbuf(1,iremote+1),ncount,MPI_INTEGER8,iremote,mpitag,MPI_COMM_WORLD,ireq2,ierr)
-    call MPI_Request_free(ireq2,ierr)
+      call MPI_iSend(itbuf(1,iremote+1),ncount,MPI_INTEGER8,iremote,mpitag,MPI_COMM_WORLD,ireq2,ierr)
+      call MPI_Request_free(ireq2,ierr)
 
-    if(idbg.gt.10) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,i5,a,2i5,a,4i5,i20)') date(1:8),time(1:8), &
-          mstr,' sent return to',iremote,mpitag,' buffer ',(itbuf(j,iremote+1),j=1,4),ireq2
-      flush(lfndbg)
-    endif
+      if(idbg.gt.10) then
+        call swatch(date,time)
+        write(lfndbg,'(a,1x,a,i5,a,2i5,a,4i5,i20)') date(1:8),time(1:8), &
+            mstr,' sent return to',iremote,mpitag,' buffer ',(itbuf(j,iremote+1),j=1,4),ireq2
+        flush(lfndbg)
+      endif
+    enddo
   enddo
  
   if(iint.gt.0) then 

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -330,7 +330,7 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
 
     !     Receive next task directly from master
     ncount=4
-    mpitag=2
+    mpitag=100+thread_id
     call MPI_Recv(ibuf,ncount,MPI_INTEGER8,mstr,mpitag,MPI_COMM_WORLD,status,ierr)
     if(ierr .ne. MPI_SUCCESS) then
       call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)


### PR DESCRIPTION
## Summary
- send each task with an MPI tag derived from the target thread id
- receive tasks using thread specific tags on workers
- propagate the same tags when signalling completion/termination

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890651ae904832ab08e27011e6ea308