### PR TITLE
Abort when MPI_THREAD_MULTIPLE unsupported

### DIFF
--- a/src/gnome/gronor_environment.F90
+++ b/src/gnome/gronor_environment.F90
@@ -70,7 +70,8 @@ subroutine gronor_environment()
   call mpi_comm_rank(MPI_COMM_WORLD,me,ierr)
   call mpi_comm_size(MPI_COMM_WORLD,np,ierr)
   if(provided_thread_level < MPI_THREAD_MULTIPLE) then
-    if(me == 0) write(*,*) 'Warning: MPI_THREAD_MULTIPLE not fully supported'
+    if(me == 0) write(*,*) 'Error: MPI_THREAD_MULTIPLE not fully supported'
+    call MPI_Abort(MPI_COMM_WORLD, 1, ierr)
   endif
 
   !     master process is last in the list to enable more effective


### PR DESCRIPTION
## Summary
- Abort execution if MPI doesn't provide `MPI_THREAD_MULTIPLE`

## Testing
- `ctest` *(fails: No test configuration file found)*
- `python3 scripts/test.py dummy` *(fails: dummy.run missing)*

------
https://chatgpt.com/codex/tasks/task_e_689066c00c30832a91f0c2448c1ab9de