### PR TITLE
Refactor MPI error handling variable names

### DIFF
--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -62,11 +62,8 @@ subroutine gronor_master()
 
   integer (kind=4) :: ierr,ireq2,ireq9,iremote,ncount,mpitag
   integer (kind=4) :: status(MPI_STATUS_SIZE)
-  integer :: mpi_err_len, ierr2
-  character(len=MPI_MAX_ERROR_STRING) :: mpi_err_str
-
-  integer :: mpi_err_len, ierr2
-  character(len=MPI_MAX_ERROR_STRING) :: mpi_err_str
+  integer :: err_len, ierr_abort
+  character(len=MPI_MAX_ERROR_STRING) :: err_msg
 
   real(kind=8), external :: timer_wall_total
 
@@ -371,10 +368,10 @@ subroutine gronor_master()
 
         call MPI_Recv(tbuf,ncount,MPI_REAL8,MPI_ANY_SOURCE,mpitag,MPI_COMM_WORLD,status,ierr)
         if(ierr .ne. MPI_SUCCESS) then
-          call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-          write(lfnmpi,'(a)') 'MPI_Recv failed: '//mpi_err_str(1:mpi_err_len)
+          call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+          write(lfnmpi,'(a)') 'MPI_Recv failed: '//err_msg(1:err_len)
           flush(lfnmpi)
-          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
         endif
         tid=int(tbuf(18))+1
         do k=1,17
@@ -752,10 +749,10 @@ subroutine gronor_master()
         if (send_req(iremote+1,tid) /= MPI_REQUEST_NULL) then
           call MPI_Wait(send_req(iremote+1,tid),status,ierr)
           if(ierr .ne. MPI_SUCCESS) then
-            call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-            write(lfnmpi,'(a)') 'MPI_Wait failed: '//mpi_err_str(1:mpi_err_len)
+            call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+            write(lfnmpi,'(a)') 'MPI_Wait failed: '//err_msg(1:err_len)
             flush(lfnmpi)
-            call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+            call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
           endif
         endif
         ipbuf(1,iremote+1,tid)=ibuf(1)
@@ -768,10 +765,10 @@ subroutine gronor_master()
         call MPI_iSend(ipbuf(1,iremote+1,tid),ncount,MPI_INTEGER8, &
             iremote,mpitag,MPI_COMM_WORLD,send_req(iremote+1,tid),ierr)
         if(ierr .ne. MPI_SUCCESS) then
-          call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-          write(lfnmpi,'(a)') 'MPI_iSend failed: '//mpi_err_str(1:mpi_err_len)
+          call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+          write(lfnmpi,'(a)') 'MPI_iSend failed: '//err_msg(1:err_len)
           flush(lfnmpi)
-          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
         endif
         write(lfnmpi,'("send task to",i0," tid",i0," ibuf=",4i12)') iremote,tid-1,ibuf
 
@@ -851,10 +848,10 @@ subroutine gronor_master()
 
     call MPI_Recv(tbuf,ncount,MPI_REAL8,MPI_ANY_SOURCE,mpitag,MPI_COMM_WORLD,status,ierr)
     if(ierr .ne. MPI_SUCCESS) then
-      call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-      write(lfnmpi,'(a)') 'MPI_Recv failed: '//mpi_err_str(1:mpi_err_len)
+      call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+      write(lfnmpi,'(a)') 'MPI_Recv failed: '//err_msg(1:err_len)
       flush(lfnmpi)
-      call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+      call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
     endif
     tid=int(tbuf(18))+1
     do k=1,17
@@ -1167,10 +1164,10 @@ subroutine gronor_master()
           if (send_req(iremote+1,tid) /= MPI_REQUEST_NULL) then
             call MPI_Wait(send_req(iremote+1,tid),status,ierr)
             if(ierr .ne. MPI_SUCCESS) then
-              call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-              write(lfnmpi,'(a)') 'MPI_Wait failed: '//mpi_err_str(1:mpi_err_len)
+              call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+              write(lfnmpi,'(a)') 'MPI_Wait failed: '//err_msg(1:err_len)
               flush(lfnmpi)
-              call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+              call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
             endif
           endif
           ipbuf(1,iremote+1,tid)=-ibuf(1)
@@ -1182,10 +1179,10 @@ subroutine gronor_master()
 
           call MPI_iSend(ipbuf(1,iremote+1,tid),ncount,MPI_INTEGER8,iremote,mpitag,MPI_COMM_WORLD,send_req(iremote+1,tid),ierr)
           if(ierr .ne. MPI_SUCCESS) then
-            call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-            write(lfnmpi,'(a)') 'MPI_iSend failed: '//mpi_err_str(1:mpi_err_len)
+            call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+            write(lfnmpi,'(a)') 'MPI_iSend failed: '//err_msg(1:err_len)
             flush(lfnmpi)
-            call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+            call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
           endif
           write(lfnmpi,'("send dup to",i0," tid",i0," ibuf=",4i12)') iremote,tid-1,ibuf
 
@@ -1295,17 +1292,17 @@ subroutine gronor_master()
 
       call MPI_iSend(itbuf(1,iremote+1),ncount,MPI_INTEGER8,iremote,mpitag,MPI_COMM_WORLD,ireq2,ierr)
       if(ierr .ne. MPI_SUCCESS) then
-        call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-        write(lfnmpi,'(a)') 'MPI_iSend failed: '//mpi_err_str(1:mpi_err_len)
+        call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+        write(lfnmpi,'(a)') 'MPI_iSend failed: '//err_msg(1:err_len)
         flush(lfnmpi)
-        call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+        call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
       endif
       call MPI_Request_free(ireq2,ierr)
       if(ierr .ne. MPI_SUCCESS) then
-        call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-        write(lfnmpi,'(a)') 'MPI_Request_free failed: '//mpi_err_str(1:mpi_err_len)
+        call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+        write(lfnmpi,'(a)') 'MPI_Request_free failed: '//err_msg(1:err_len)
         flush(lfnmpi)
-        call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+        call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
       endif
 
       if(idbg.gt.10) then
@@ -1330,17 +1327,17 @@ subroutine gronor_master()
       if(iremote.ne.mstr) then
         call MPI_iSend(itbuf(1,iremote+1),ncount,MPI_INTEGER8,iremote,mpitag,MPI_COMM_WORLD,ireq9,ierr)
         if(ierr .ne. MPI_SUCCESS) then
-          call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-          write(lfnmpi,'(a)') 'MPI_iSend failed: '//mpi_err_str(1:mpi_err_len)
+          call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+          write(lfnmpi,'(a)') 'MPI_iSend failed: '//err_msg(1:err_len)
           flush(lfnmpi)
-          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
         endif
         call MPI_Request_free(ireq9,ierr)
         if(ierr .ne. MPI_SUCCESS) then
-          call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-          write(lfnmpi,'(a)') 'MPI_Request_free failed: '//mpi_err_str(1:mpi_err_len)
+          call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+          write(lfnmpi,'(a)') 'MPI_Request_free failed: '//err_msg(1:err_len)
           flush(lfnmpi)
-          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
         endif
         if(idbg.gt.10) then
           call swatch(date,time)
@@ -1451,10 +1448,10 @@ subroutine gronor_master()
       if (send_req(i,tid) /= MPI_REQUEST_NULL) then
         call MPI_Wait(send_req(i,tid),status,ierr)
         if(ierr .ne. MPI_SUCCESS) then
-          call MPI_Error_string(ierr, mpi_err_str, mpi_err_len, ierr2)
-          write(lfnmpi,'(a)') 'MPI_Wait failed: '//mpi_err_str(1:mpi_err_len)
+          call MPI_Error_string(ierr, err_msg, err_len, ierr_abort)
+          write(lfnmpi,'(a)') 'MPI_Wait failed: '//err_msg(1:err_len)
           flush(lfnmpi)
-          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr2)
+          call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
         endif
       endif
     enddo


### PR DESCRIPTION
## Summary
- Rename MPI error-handling locals in gronor_master to err_len, err_msg, and ierr_abort
- Update MPI_Error_string and MPI_Abort calls to use new local names

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_6890a0fb101c832aa7fc8846e96e8b2c