### PR TITLE
Fix missing enddo in thread cleanup loop

### DIFF
--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -1455,6 +1455,7 @@ subroutine gronor_master()
         endif
       endif
     enddo
+  enddo
 
   close(lfnmpi)
   deallocate(pnrb,fday,lgroup,lactive,ntasks,ndets,ipbuf,send_req,lcount)


### PR DESCRIPTION
## Summary
- Close remaining `do tid` loop in `gronor_master.F90`
- Ensures MPI requests are properly handled before cleanup

## Testing
- `ctest` *(fails: No test configuration file found)*
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get install -y gfortran` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6890a93d0254832a89f1dd495a8e6c60