### PR TITLE
Fix missing endif in MPI termination loop

### DIFF
--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -1344,6 +1344,7 @@ subroutine gronor_master()
           write(lfndbg,'(a,1x,a,a,2i5,a,4i5,i20)') date(1:8),time(1:8), &
               ' Terminate signal sent to',iremote,mpitag,' buffer ',(itbuf(j,iremote+1),j=1,4),ireq9
         endif
+      endif
     enddo
   endif
 


### PR DESCRIPTION
## Summary
- Close missing `if(iremote.ne.mstr)` branch in master routine to repair control flow

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b9c78d24832a93c74da21344fd07