### PR TITLE
Fix MPI error routine types

### DIFF
--- a/src/gnome/gronor_abort.F90
+++ b/src/gnome/gronor_abort.F90
@@ -8,7 +8,7 @@
 
       character*(*) :: string
       integer :: icode
-      integer (kind=4) :: ierror,ierr
+      integer :: ierror, ierr
       character (len=255) :: filabt
 !
 !     error termination

--- a/src/gnome/gronor_environment.F90
+++ b/src/gnome/gronor_environment.F90
@@ -37,8 +37,8 @@ subroutine gronor_environment()
 !  external :: MPI_AllReduce
 
   integer :: i,j,k,node
-  integer (kind=4) :: length, ierr, ncount, provided_thread_level, ierr2
-  !      integer (kind=4) :: istat
+  integer :: length, ierr, ncount, provided_thread_level, ierr2
+  !      integer :: istat
 
   integer :: getcpucount
   external :: getcpucount

--- a/src/gnome/gronor_main.F90
+++ b/src/gnome/gronor_main.F90
@@ -92,7 +92,7 @@ subroutine gronor_main()
 
 !  external :: MPI_Bcast
 
-  integer (kind=4) :: ierror,ierr,ncount
+  integer :: ierror, ierr, ncount
   integer (kind=8) :: iarg,i,j,jp,idum(55),k,l,iact
   integer :: node
   real (kind=8) :: rdum(6)
@@ -105,7 +105,7 @@ subroutine gronor_main()
   external :: getcpucount
 
   integer :: igr,numone,numtwo,maxgrp
-  integer (kind=4) :: new
+  integer :: new
 
   integer :: ibase,jbase,lnxt,lcur,ksr,nsr(4)
 

--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -60,8 +60,8 @@ subroutine gronor_master()
   real (kind=8) :: tbuf(18)
   integer :: gtid, lfnmpi
 
-  integer (kind=4) :: ierr,ireq2,ireq9,iremote,ncount,mpitag
-  integer (kind=4) :: status(MPI_STATUS_SIZE)
+  integer :: ierr, ireq2, ireq9, iremote, ncount, mpitag
+  integer :: status(MPI_STATUS_SIZE)
   integer :: err_len, ierr_abort
   character(len=MPI_MAX_ERROR_STRING) :: err_msg
 
@@ -1344,6 +1344,7 @@ subroutine gronor_master()
           write(lfndbg,'(a,1x,a,a,2i5,a,4i5,i20)') date(1:8),time(1:8), &
               ' Terminate signal sent to',iremote,mpitag,' buffer ',(itbuf(j,iremote+1),j=1,4),ireq9
         endif
+      endif
     enddo
   endif
 

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -39,9 +39,9 @@ subroutine gronor_worker()
 
   integer :: ibase,jbase,idet,jdet,nidet,njdet
   integer :: i,j,k,l2,n,iact
-  integer (kind=4) :: ireq,ierr,ncount,mpitag,mpidest
+  integer :: ireq, ierr, ncount, mpitag, mpidest
   integer (kind=8) :: ibuf(4)
-  integer (kind=4) :: status(MPI_STATUS_SIZE)
+  integer :: status(MPI_STATUS_SIZE)
   real (kind=8) :: tbuf(18)
   integer :: thread_id, lfnmpi
   character(len=128) :: mpifile
@@ -53,7 +53,7 @@ subroutine gronor_worker()
   real (kind=8), allocatable :: w1(:),w2(:,:)
   real (kind=8), allocatable :: taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
 
-  logical (kind=4) :: flag
+  logical :: flag
 
   ! Manager layer removed; master rank stored globally in mstr
   
@@ -249,16 +249,16 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
 
   integer :: ibase,jbase,idet,jdet,nidet,njdet
   integer :: i,j,k,l2,n,iact
-  integer (kind=4) :: ireq,ierr,ncount,mpitag,mpidest
+  integer :: ireq, ierr, ncount, mpitag, mpidest
   integer (kind=8) :: ibuf(4)
-  integer (kind=4) :: status(MPI_STATUS_SIZE)
+  integer :: status(MPI_STATUS_SIZE)
   real (kind=8) :: tbuf(18)
   integer :: thread_id, lfnmpi
   character(len=128) :: mpifile
   integer :: mpi_err_len, ierr2
   character(len=MPI_MAX_ERROR_STRING) :: mpi_err_str
 
-  logical (kind=4) :: flag
+  logical :: flag
 
   thread_id = omp_get_thread_num()
   if(idbg.gt.0) then


### PR DESCRIPTION
## Summary
- Close missing `if(iremote.ne.mstr)` branch in master routine to repair control flow
- Use default integer/logical kinds for MPI error handling routines across master, environment, worker and supporting modules

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b9c78d24832a93c74da21344fd07