### PR TITLE
Fix MPI_Abort argument types

### DIFF
--- a/src/gnome/gronor_abort.F90
+++ b/src/gnome/gronor_abort.F90
@@ -8,7 +8,7 @@
 
       character*(*) :: string
       integer :: icode
-      integer :: err_code, ierr_abort
+      integer(MPI_INTEGER_KIND) :: err_code, ierr_abort
       character (len=255) :: filabt
 !
 !     error termination
@@ -228,7 +228,7 @@
 
       close(unit=lfnabt)
 !
-      err_code = 0
+      err_code = int(icode, MPI_INTEGER_KIND)
       call MPI_Abort(MPI_COMM_WORLD, err_code, ierr_abort)
 !
       return


### PR DESCRIPTION
## Summary
- ensure MPI_Abort uses MPI integer kind for error code

## Testing
- `cmake -S . -B build` (fails: No CMAKE_Fortran_COMPILER could be found)
- `apt-get update` (fails: repository not signed)
- `apt-get install -y gfortran` (fails: Unable to locate package gfortran)


------
https://chatgpt.com/codex/tasks/task_e_6890cd960ae8832a92d91c60c0460cd0