### PR TITLE
Use default integer kind for MPI variables

### DIFF
--- a/src/gnome/gronor_abort.F90
+++ b/src/gnome/gronor_abort.F90
@@ -8,7 +8,7 @@
 
       character*(*) :: string
       integer :: icode
-      integer(MPI_INTEGER_KIND) :: err_code, ierr_abort
+      integer(kind=4) :: err_code, ierr_abort
       character (len=255) :: filabt
 !
 !     error termination
@@ -228,7 +228,7 @@
 
       close(unit=lfnabt)
 !
-      err_code = int(icode, MPI_INTEGER_KIND)
+      err_code = int(icode, kind=4)
       call MPI_Abort(MPI_COMM_WORLD, err_code, ierr_abort)
 !
       return

--- a/src/gnome/gronor_environment.F90
+++ b/src/gnome/gronor_environment.F90
@@ -36,12 +36,12 @@ subroutine gronor_environment()
   external :: hostnm
 !  external :: MPI_AllReduce
 
-  integer(MPI_INTEGER_KIND) :: i,j,k,node
-  integer(MPI_INTEGER_KIND) :: length, ierr, provided_thread_level, ierr2
-  integer(MPI_COUNT_KIND) :: ncount
+  integer(kind=4) :: i,j,k,node
+  integer(kind=4) :: length, ierr, provided_thread_level, ierr2
+  integer(kind=4) :: ncount
   !      integer :: istat
 
-  integer(MPI_INTEGER_KIND) :: getcpucount
+  integer(kind=4) :: getcpucount
   external :: getcpucount
 
   character (len=MPI_MAX_PROCESSOR_NAME) :: nodename
@@ -49,7 +49,7 @@ subroutine gronor_environment()
   character (len=40) :: numeric
   character (len=128) :: value
 
-  integer(MPI_INTEGER_KIND) :: lenv,statv
+  integer(kind=4) :: lenv,statv
 
   logical ohost
 
@@ -452,7 +452,7 @@ subroutine gronor_environment()
     map1(me+1,4)=node
     map1(me+1,5)=0
     map1(me+1,6)=0
-    ncount=int(4*np, MPI_COUNT_KIND)
+    ncount=int(4*np, kind=4)
     call MPI_Allreduce(map1, map2, ncount, MPI_INTEGER, MPI_SUM,               &
         & MPI_COMM_WORLD, ierr)
 

--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -44,10 +44,10 @@ module cidist
   !     comm_first : communicator of all first processes in each group
   !     mpibuf : size of the MPI buffer for integrals in reals
 
-  integer (MPI_INTEGER_KIND) :: me,np,mstr,rocinfo
-  integer (MPI_INTEGER_KIND) :: numdev,mydev
-  integer (MPI_INTEGER_KIND) :: group_batch,group_heads,group_world
-  integer (MPI_INTEGER_KIND), allocatable :: ranks_list(:),ranks_heads(:)
+  integer (kind=4) :: me,np,mstr,rocinfo
+  integer (kind=4) :: numdev,mydev
+  integer (kind=4) :: group_batch,group_heads,group_world
+  integer (kind=4), allocatable :: ranks_list(:),ranks_heads(:)
 
   integer :: nnodes,nrsets,nranks,ncycls,nrnsets,ngpus
 
@@ -55,11 +55,11 @@ module cidist
   integer :: ngr,meg,npg,comm_group,comm_first,mgr,nalive,nabort
   integer :: mynode,mygroup,myhead,ime,mpibuf
   integer :: iamhead,iamacc,iamactive,nonidle
-  integer (MPI_INTEGER_KIND), allocatable  :: map1(:,:),map2(:,:)
+  integer (kind=4), allocatable  :: map1(:,:),map2(:,:)
   integer, allocatable :: thisgroup(:),allgroups(:,:),allheads(:)
   integer, allocatable :: numrecs(:)
   integer (kind=8), allocatable :: ipbuf(:,:,:),itbuf(:,:)
-  integer (MPI_INTEGER_KIND), allocatable :: send_req(:,:)
+  integer (kind=4), allocatable :: send_req(:,:)
 
   !     OpenMP distribution
 
@@ -70,20 +70,20 @@ module cidist
   !     Accelerator data
 
   integer (kind=8), target :: memfre,memtot,memavail
-  integer (MPI_INTEGER_KIND), allocatable :: igrn(:)
+  integer (kind=4), allocatable :: igrn(:)
 
   ! Manager layer removed; retain only variables used by master and workers
   ! formerly: managers,numwrk,maxbuf,numbuf,mgrbuf,mgrwrk,mipbuf
   
   character (len=12) :: machine
 
-  integer (MPI_INTEGER_KIND), parameter :: master=1
-  integer (MPI_INTEGER_KIND), parameter :: worker=2
-  integer (MPI_INTEGER_KIND), parameter :: idle=3
+  integer (kind=4), parameter :: master=1
+  integer (kind=4), parameter :: worker=2
+  integer (kind=4), parameter :: idle=3
 
   character (len=1), parameter :: crole(3)=(/"M","w","i"/)
 
-  integer (MPI_INTEGER_KIND) :: role
+  integer (kind=4) :: role
 
 end module cidist
 


### PR DESCRIPTION
## Summary
- revert MPI-related declarations to `integer(kind=4)`
- adjust error handling to use default integer kind
- ensure MPI environment setup uses default integer counts

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_6890d483a6b0832a9444d34538b43ecc