### PR TITLE
Specify 4-byte integers for MPI variables

### DIFF
--- a/src/gnome/gronor_main.F90
+++ b/src/gnome/gronor_main.F90
@@ -92,7 +92,7 @@ subroutine gronor_main()
 
 !  external :: MPI_Bcast
 
-  integer :: ierror, ierr, ncount
+  integer (kind=4) :: ierror, ierr, ncount
   integer (kind=8) :: iarg,i,j,jp,idum(55),k,l,iact
   integer :: node
   real (kind=8) :: rdum(6)
@@ -105,7 +105,7 @@ subroutine gronor_main()
   external :: getcpucount
 
   integer :: igr,numone,numtwo,maxgrp
-  integer :: new
+  integer (kind=4) :: new
 
   integer :: ibase,jbase,lnxt,lcur,ksr,nsr(4)
 


### PR DESCRIPTION
## Summary
- Ensure MPI-related counters use 4-byte integers in `gronor_main.F90`

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `ctest --test-dir build` *(No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e0a2da00832a8d91ca9ae78239aa