### PR TITLE
Restore 4-byte MPI variable types

### DIFF
--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -60,8 +60,8 @@ subroutine gronor_master()
   real (kind=8) :: tbuf(18)
   integer :: gtid, lfnmpi
 
-  integer :: ierr, ireq2, ireq9, iremote, ncount, mpitag
-  integer :: status(MPI_STATUS_SIZE)
+  integer (kind=4) :: ierr, ireq2, ireq9, iremote, ncount, mpitag
+  integer (kind=4) :: status(MPI_STATUS_SIZE)
   integer :: err_len, ierr_abort
   character(len=MPI_MAX_ERROR_STRING) :: err_msg
 

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -39,9 +39,9 @@ subroutine gronor_worker()
 
   integer :: ibase,jbase,idet,jdet,nidet,njdet
   integer :: i,j,k,l2,n,iact
-  integer :: ireq, ierr, ncount, mpitag, mpidest
+  integer (kind=4) :: ireq, ierr, ncount, mpitag, mpidest
   integer (kind=8) :: ibuf(4)
-  integer :: status(MPI_STATUS_SIZE)
+  integer (kind=4) :: status(MPI_STATUS_SIZE)
   real (kind=8) :: tbuf(18)
   integer :: thread_id, lfnmpi
   character(len=128) :: mpifile
@@ -53,7 +53,7 @@ subroutine gronor_worker()
   real (kind=8), allocatable :: w1(:),w2(:,:)
   real (kind=8), allocatable :: taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
 
-  logical :: flag
+  logical (kind=4) :: flag
 
   ! Manager layer removed; master rank stored globally in mstr
   


### PR DESCRIPTION
## Summary
- Restore 4-byte integer declarations for MPI variables in master and worker routines
- Use 4-byte logical for worker control flag

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e3da34d4832a9ae52c81de234ee9