### PR TITLE
Fix MPI integer kinds in gronor_master

### DIFF
--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -60,8 +60,8 @@ subroutine gronor_master()
   real (kind=8) :: tbuf(18)
   integer :: gtid, lfnmpi
 
-  integer (kind=4) :: ierr, ireq2, ireq9, iremote, ncount, mpitag
-  integer (kind=4) :: status(MPI_STATUS_SIZE)
+  integer :: ierr, ireq2, ireq9, iremote, ncount, mpitag
+  integer :: status(MPI_STATUS_SIZE)
   integer :: err_len, ierr_abort
   character(len=MPI_MAX_ERROR_STRING) :: err_msg
 


### PR DESCRIPTION
## Summary
- use default integer kinds for MPI status and error codes to avoid generic resolution failures

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `sudo apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890e7019688832a9cdf9a3b589370d8