### PR TITLE
Refactor gronor_worker_process as internal procedure

### DIFF
--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -217,11 +217,12 @@ subroutine gronor_worker()
 !    call MPI_Test(itreq,flag,status,ierr)
 !    if(.not.flag) call MPI_Request_free(itreq,ierr)
 !  endif
-  
-  return
-end subroutine gronor_worker
 
-subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+  return
+
+contains
+
+  subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   use mpi
   use cidef
@@ -524,4 +525,6 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
   close(lfnmpi)
 
   return
-end subroutine gronor_worker_process
+  end subroutine gronor_worker_process
+
+end subroutine gronor_worker


### PR DESCRIPTION
## Summary
- Turn `gronor_worker_process` into an internal procedure of `gronor_worker` using `contains`

## Testing
- `ctest` (fails: No test configuration file found)
- `cmake -S . -B build` (fails: No CMAKE_Fortran_COMPILER could be found)


------
https://chatgpt.com/codex/tasks/task_e_6890ec721758832aa800d89ce7043427