### PR TITLE
Modularize GNOME calculation subroutines

### DIFF
--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -29,17 +29,19 @@
 !!    @date    2016
 
 
-subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
-
+module gronor_calculate_mod
   use mpi
   use cidist
   use cidef
   use gnome_data
   use gnome_parameters
-
 #ifdef _OPENMP
   use omp_lib
 #endif
+  use gronor_gnome_mod, only: gronor_gnome
+  implicit none
+contains
+subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   implicit none
 
@@ -49,8 +51,7 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
 
   external :: swatch,timer_start,timer_stop
-!  external :: MPI_iSend,MPI_Recv
-  external :: gronor_gnome,gronor_abort
+  external :: gronor_abort
 
   integer (kind=4) :: ireq,ierr
   integer (kind=4) :: iremote,status(MPI_STATUS_SIZE)
@@ -441,3 +442,5 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
 
   return
 end subroutine gronor_calculate
+
+end module gronor_calculate_mod

--- a/src/gnome/gronor_cofac1.F90
+++ b/src/gnome/gronor_cofac1.F90
@@ -20,12 +20,15 @@
 !! @date    2016
 !!
 
-      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
+      module gronor_cofac1_mod
       use cidist
       use gnome_parameters
       use gnome_data
       use gnome_solvers
-      
+      implicit none
+      contains
+      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
+
       implicit none
 
       real (kind=8), intent(inout) :: a(:,:),u(:,:),w(:,:),wt(:,:),ev(:),ta(:,:)
@@ -280,3 +283,5 @@
 
       return
       end subroutine gronor_cofac1
+
+      end module gronor_cofac1_mod

--- a/src/gnome/gronor_cororb.F90
+++ b/src/gnome/gronor_cororb.F90
@@ -19,9 +19,12 @@
 !! @date    2016
 !!
 
-subroutine gronor_cororb(u,w,va,vb,ev)
+module gronor_cororb_mod
   use gnome_parameters
   use gnome_data
+  implicit none
+contains
+subroutine gronor_cororb(u,w,va,vb,ev)
   implicit none
   real (kind=8), intent(inout) :: u(:,:),w(:,:),va(:,:),vb(:,:),ev(:)
   integer :: i,j,k
@@ -43,3 +46,5 @@ subroutine gronor_cororb(u,w,va,vb,ev)
 
   return
 end subroutine gronor_cororb
+
+end module gronor_cororb_mod

--- a/src/gnome/gronor_dipole.F90
+++ b/src/gnome/gronor_dipole.F90
@@ -19,10 +19,13 @@
 !! @date    2016
 !!
 
-subroutine gronor_dipole(lfndbg,ta,diag,sdiag)
+module gronor_dipole_mod
   use cidist
   use gnome_parameters
   use gnome_data
+  implicit none
+contains
+subroutine gronor_dipole(lfndbg,ta,diag,sdiag)
   implicit none
   integer :: lfndbg
   real (kind=8), intent(inout) :: ta(:,:),diag(:),sdiag(:)
@@ -114,4 +117,6 @@ subroutine gronor_dipole(lfndbg,ta,diag,sdiag)
 
   return
 end subroutine gronor_dipole
+
+end module gronor_dipole_mod
 

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -20,14 +20,22 @@
 !!
 
 
-subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
-
+module gronor_gnome_mod
   use mpi
   use cidist
   use gnome_integrals
   use gnome_parameters
   use gnome_data
-  !      use nvtx
+  use gronor_moover_mod,    only: gronor_moover
+  use gronor_cofac1_mod,    only: gronor_cofac1
+  use gronor_cororb_mod,    only: gronor_cororb
+  use gronor_gntwo_mod,     only: gronor_gntwo, gronor_gntwo_canonical
+  use gronor_gnone_mod,     only: gronor_gnone
+  use gronor_tramat2_mod,   only: gronor_tramat2
+  use gronor_dipole_mod,    only: gronor_dipole
+  implicit none
+contains
+subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   implicit none
 
@@ -37,15 +45,6 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
 
   external :: timer_start,timer_stop
-  external :: gronor_dipole
-  external :: gronor_cororb
-  external :: gronor_gntwo
-  external :: gronor_gntwo_canonical
-!  external :: gronor_gntwo_batch_indexed
-  external :: gronor_gnone
-  external :: gronor_tramat2
-  external :: gronor_cofac1
-  external :: gronor_moover
   external :: gronor_abort
   external :: gronor_tranout
   external :: gronor_transvc
@@ -254,3 +253,5 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
 
   return
 end subroutine gronor_gnome
+
+end module gronor_gnome_mod

--- a/src/gnome/gronor_gnone.F90
+++ b/src/gnome/gronor_gnone.F90
@@ -27,12 +27,14 @@
 !!
 
 
-subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
+module gronor_gnone_mod
   use cidist
   use gnome_parameters
   use gnome_data
   use gnome_integrals
-
+  implicit none
+contains
+subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
   implicit none
   integer :: lfndbg
   real (kind=8), intent(inout) :: diag(:),bdiag(:),bsdiag(:),csdiag(:),ta(:,:),aaa(:,:)
@@ -187,3 +189,5 @@ subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
   endif
   return
 end subroutine gronor_gnone
+
+end module gronor_gnone_mod

--- a/src/gnome/gronor_gntwo.F90
+++ b/src/gnome/gronor_gntwo.F90
@@ -28,17 +28,18 @@
 !! </table>
 !!
 
-subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
-
+module gronor_gntwo_mod
   use mpi
   use cidist
   use gnome_parameters
   use gnome_data
   use gnome_integrals
   use iso_c_binding, only : c_loc, c_ptr
-
   use openacc
   use cuda_functions
+  implicit none
+contains
+subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
   implicit none
 
@@ -587,3 +588,5 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
 
   return
 end subroutine gronor_gntwo_canonical
+
+end module gronor_gntwo_mod

--- a/src/gnome/gronor_moover.F90
+++ b/src/gnome/gronor_moover.F90
@@ -19,13 +19,15 @@
 !! @date    2016
 !!
 
-subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
-
+module gronor_moover_mod
   use mpi
   use cidist
   use gnome_integrals
   use gnome_parameters
   use gnome_data
+  implicit none
+contains
+subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 
   implicit none
 
@@ -195,4 +197,6 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 
   return
 end subroutine gronor_moover
+
+end module gronor_moover_mod
 

--- a/src/gnome/gronor_tramat2.F90
+++ b/src/gnome/gronor_tramat2.F90
@@ -19,15 +19,18 @@
 !! @date    2016
 !!
 
+module gronor_tramat2_mod
+  use cidist
+  use gnome_parameters
+  use gnome_data
+  implicit none
+contains
 subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
 
   !      Transformation of the  m.o.'s
   !      the new  m.o.'s are adapted to the basis set of the two electon
   !      integrals
 
-  use cidist
-  use gnome_parameters
-  use gnome_data
   implicit none
   integer :: lfndbg
   real (kind=8), intent(inout) :: va(:,:),vb(:,:),ta(:,:),aaa(:,:),w1(:),w2(:,:),diag(:),bdiag(:),bsdiag(:),cdiag(:),csdiag(:),sdiag(:)
@@ -289,3 +292,5 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
 
   return
 end subroutine gronor_tramat2
+
+end module gronor_tramat2_mod

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -26,11 +26,12 @@ subroutine gronor_worker()
   use gnome_parameters
   use gnome_solvers
   use omp_lib
+  use gronor_calculate_mod, only: gronor_calculate
 
   implicit none
 
   external :: gronor_solver_init,gronor_solver_final
-  external :: gronor_calculate,gronor_abort
+  external :: gronor_abort
   external :: swatch,timer_start,timer_stop
 
 !  external :: MPI_Recv,MPI_iRecv,MPI_iSend
@@ -217,11 +218,12 @@ subroutine gronor_worker()
 !    call MPI_Test(itreq,flag,status,ierr)
 !    if(.not.flag) call MPI_Request_free(itreq,ierr)
 !  endif
-  
-  return
-end subroutine gronor_worker
 
-subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+  return
+
+contains
+
+  subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   use mpi
   use cidef
@@ -240,7 +242,7 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
 
   external :: gronor_solver_init,gronor_solver_final
-  external :: gronor_calculate,gronor_abort
+  external :: gronor_abort
   external :: swatch,timer_start,timer_stop
 
 !  external :: MPI_Recv,MPI_iRecv,MPI_iSend
@@ -524,4 +526,6 @@ subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt
   close(lfnmpi)
 
   return
-end subroutine gronor_worker_process
+  end subroutine gronor_worker_process
+
+end subroutine gronor_worker


### PR DESCRIPTION
## Summary
- Wrap `gronor_calculate`, `gronor_gnome`, and all supporting routines in their own modules to supply explicit interfaces for assumed-shape arrays
- Update `gronor_worker` to use the new `gronor_calculate_mod` module, ensuring safe calls from the worker process

## Testing
- `cmake -S . -B build` (fails: No CMAKE_Fortran_COMPILER could be found)
- `ctest` (fails: No test configuration file found)


------
https://chatgpt.com/codex/tasks/task_e_6890ec721758832aa800d89ce7043427