### PR TITLE
Ensure worker arrays are passed explicitly to process routine

### DIFF
--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -206,7 +206,7 @@ subroutine gronor_worker()
   endif
 
 
-  call gronor_worker_process()
+  call gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   call gronor_solver_finalize()
 
@@ -259,7 +259,7 @@ subroutine gronor_worker()
 
 contains
 
-  subroutine gronor_worker_process()
+  subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   use mpi
   use cidef
@@ -271,6 +271,11 @@ contains
   use omp_lib
 
   implicit none
+
+  real (kind=8), intent(inout) :: va(:,:),vb(:,:),tb(:,:),ta(:,:),a(:,:)
+  real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
+  real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
+  real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
 
 !  external :: MPI_Recv,MPI_iRecv,MPI_iSend
 


### PR DESCRIPTION
## Summary
- Pass scratch arrays to `gronor_worker_process` explicitly to avoid host association issues with OpenMP private variables
- Declare corresponding dummy arguments so that downstream calls use the thread-local data

## Testing
- `ctest` *(fails: No test configuration file found)*
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_689243ecd3d8832a838aa82f9ded5cfd