### PR TITLE
Add debug dimension checks and initialize worker variables

### DIFF
--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -53,25 +53,69 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
   external :: swatch,timer_start,timer_stop
   external :: gronor_abort
 
-  integer (kind=4) :: ireq,ierr
-  integer (kind=4) :: iremote,status(MPI_STATUS_SIZE)
-  integer (kind=4) :: ncount,mpitag,mpidest
-  integer :: ib,jb,id1,id2,ii,ihc,nhc,iact
+  integer (kind=4) :: ireq=0,ierr=0
+  integer (kind=4) :: iremote=0,status(MPI_STATUS_SIZE)=0
+  integer (kind=4) :: ncount=0,mpitag=0,mpidest=0
+  integer :: ib,jb,id1,id2,ii=0,ihc=0,nhc=0,iact=0
 
-  integer :: i,ibv,idet,ij,j,k,l2,m,nop,nvc,indxx
-  integer :: idown,iup,iv,ncleff,nopeff,mspin,iclose,nb,ncl,indexv
-  integer :: ntvc,ivc,ibas
+  integer :: i=0,ibv=0,idet=0,ij=0,j=0,k=0,l2=0,m=0,nop=0,nvc=0,indxx=0
+  integer :: idown=0,iup=0,iv=0,ncleff=0,nopeff=0,mspin=0,iclose=0,nb=0,ncl=0,indexv=0
+  integer :: ntvc=0,ivc=0,ibas=0
 
-  integer :: ioff
+  integer :: ioff=0
 
-  real (kind=8) :: btemp,btemp2
+  real (kind=8) :: btemp=0.0d0,btemp2=0.0d0
 
-  logical (kind=4) :: flag
+  logical (kind=4) :: flag=.false.
+
+  integer :: thread_id
+
+#ifdef _OPENMP
+  thread_id = omp_get_thread_num()
+#else
+  thread_id = 0
+#endif
 
   ndeti=idetb(ib)
   ndetj=idetb(jb)
   nacti=nactb(ib)
   nactj=nactb(jb)
+
+  if(idbg.gt.10 .and. thread_id==0) then
+    call swatch(date,time)
+    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), " Array dimensions check in gronor_calculate:"
+    write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
+    write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
+    write(lfndbg,'(a,2i10)') " tb:    ", size(tb,1), size(tb,2)
+    write(lfndbg,'(a,2i10)') " ta:    ", size(ta,1), size(ta,2)
+    write(lfndbg,'(a,2i10)') " a:     ", size(a,1), size(a,2)
+    write(lfndbg,'(a,2i10)') " u:     ", size(u,1), size(u,2)
+    write(lfndbg,'(a,2i10)') " w:     ", size(w,1), size(w,2)
+    write(lfndbg,'(a,2i10)') " wt:    ", size(wt,1), size(wt,2)
+    write(lfndbg,'(a,2i10)') " sm:    ", size(sm,1), size(sm,2)
+    write(lfndbg,'(a,2i10)') " aaa:   ", size(aaa,1), size(aaa,2)
+    write(lfndbg,'(a,2i10)') " aat:   ", size(aat,1), size(aat,2)
+    write(lfndbg,'(a,2i10)') " tt:    ", size(tt,1), size(tt,2)
+    write(lfndbg,'(a,i10)')  " ev:    ", size(ev)
+    write(lfndbg,'(a,i10)')  " w1:    ", size(w1)
+    write(lfndbg,'(a,2i10)') " w2:    ", size(w2,1), size(w2,2)
+    write(lfndbg,'(a,i10)')  " sdiag: ", size(sdiag)
+    write(lfndbg,'(a,i10)')  " diag:  ", size(diag)
+    write(lfndbg,'(a,i10)')  " bsdiag:", size(bsdiag)
+    write(lfndbg,'(a,i10)')  " bdiag: ", size(bdiag)
+    write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
+    write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
+    write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
+    write(lfndbg,'(a,i10)')  " ib:    ", ib
+    write(lfndbg,'(a,i10)')  " jb:    ", jb
+    write(lfndbg,'(a,i10)')  " id1:   ", id1
+    write(lfndbg,'(a,i10)')  " id2:   ", id2
+    write(lfndbg,'(a,i10)')  " ndeti: ", ndeti
+    write(lfndbg,'(a,i10)')  " ndetj: ", ndetj
+    write(lfndbg,'(a,i10)')  " nacti: ", nacti
+    write(lfndbg,'(a,i10)')  " nactj: ", nactj
+    flush(lfndbg)
+  endif
   if(idbg.ge.50) then
     write(lfndbg,600) ib,jb,id1,id2
 600 format(/,20('*'),' ',i5,' -',i5,' : ',i5,' -',i5,' ',20('*'))

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -26,6 +26,9 @@ module gronor_gnome_mod
   use gnome_integrals
   use gnome_parameters
   use gnome_data
+#ifdef _OPENMP
+  use omp_lib
+#endif
   use gronor_moover_mod,    only: gronor_moover
   use gronor_cofac1_mod,    only: gronor_cofac1
   use gronor_cororb_mod,    only: gronor_cororb
@@ -48,12 +51,21 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   external :: gronor_abort
   external :: gronor_tranout
   external :: gronor_transvc
+  external :: swatch
 
-  integer :: lfndbg,idet,k,iv,ib,ihc,nhc,ntvc,ivc,ibas
+  integer :: lfndbg,ihc,nhc
+  integer :: idet=0,k=0,iv=0,ib=0,ntvc=0,ivc=0,ibas=0
 
-  logical (kind=4) :: flag
-  integer (kind=4) :: ierr,status(MPI_STATUS_SIZE)
+  logical (kind=4) :: flag=.false.
+  integer (kind=4) :: ierr=0,status(MPI_STATUS_SIZE)=0
 
+  integer :: thread_id
+
+#ifdef _OPENMP
+  thread_id = omp_get_thread_num()
+#else
+  thread_id = 0
+#endif
 
   e1=0.0d0
   e2=0.0d0
@@ -118,6 +130,40 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   n1bas=nbas*(nbas+1)/2
   nstdim=max(1,nelecs*nelecs,n1bas)
   mbasel=max(nelecs,nbas)
+
+  if(idbg.gt.10 .and. thread_id==0) then
+    call swatch(date,time)
+    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), " Array dimensions check in gronor_gnome:"
+    write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
+    write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
+    write(lfndbg,'(a,2i10)') " tb:    ", size(tb,1), size(tb,2)
+    write(lfndbg,'(a,2i10)') " ta:    ", size(ta,1), size(ta,2)
+    write(lfndbg,'(a,2i10)') " a:     ", size(a,1), size(a,2)
+    write(lfndbg,'(a,2i10)') " u:     ", size(u,1), size(u,2)
+    write(lfndbg,'(a,2i10)') " w:     ", size(w,1), size(w,2)
+    write(lfndbg,'(a,2i10)') " wt:    ", size(wt,1), size(wt,2)
+    write(lfndbg,'(a,2i10)') " sm:    ", size(sm,1), size(sm,2)
+    write(lfndbg,'(a,2i10)') " aaa:   ", size(aaa,1), size(aaa,2)
+    write(lfndbg,'(a,2i10)') " aat:   ", size(aat,1), size(aat,2)
+    write(lfndbg,'(a,2i10)') " tt:    ", size(tt,1), size(tt,2)
+    write(lfndbg,'(a,i10)')  " ev:    ", size(ev)
+    write(lfndbg,'(a,i10)')  " w1:    ", size(w1)
+    write(lfndbg,'(a,2i10)') " w2:    ", size(w2,1), size(w2,2)
+    write(lfndbg,'(a,i10)')  " sdiag: ", size(sdiag)
+    write(lfndbg,'(a,i10)')  " diag:  ", size(diag)
+    write(lfndbg,'(a,i10)')  " bsdiag:", size(bsdiag)
+    write(lfndbg,'(a,i10)')  " bdiag: ", size(bdiag)
+    write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
+    write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
+    write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
+    write(lfndbg,'(a,i10)')  " ihc:   ", ihc
+    write(lfndbg,'(a,i10)')  " nhc:   ", nhc
+    write(lfndbg,'(a,i10)')  " nveca: ", nveca
+    write(lfndbg,'(a,i10)')  " nvecb: ", nvecb
+    write(lfndbg,'(a,i10)')  " nelecs:", nelecs
+    write(lfndbg,'(a,i10)')  " mbasel:", mbasel
+    flush(lfndbg)
+  endif
 
   if(nveca.ne.ntcl(1)+ntop(1)) call gronor_abort(306,"Incompatible nveca")
   if(nvecb.ne.ntcl(2)+ntop(2)) call gronor_abort(307,"Incompatible nvecb")

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -175,9 +175,9 @@ subroutine gronor_worker()
     flush(lfndbg)
   endif
 
-  if(idbg.gt.50 .and. thread_id==0) then
+  if(idbg.gt.10 .and. thread_id==0) then
     call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), " Array dimensions check:"
+    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), " Array dimensions check in gronor_worker_process:"
     ! 输出二维数组维度
     write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
     write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
@@ -202,11 +202,16 @@ subroutine gronor_worker()
     write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
     write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
     write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
+    write(lfndbg,'(a,i10)')  " nelecs:", nelecs
+    write(lfndbg,'(a,i10)')  " nveca: ", nveca
+    write(lfndbg,'(a,i10)')  " nvecb: ", nvecb
+    write(lfndbg,'(a,i10)')  " mbasel:", mbasel
+    write(lfndbg,'(a,i10)')  " nstdim:", nstdim
     flush(lfndbg)
   endif
 
 
-  call gronor_worker_process()
+  call gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   call gronor_solver_finalize()
 
@@ -259,7 +264,7 @@ subroutine gronor_worker()
 
 contains
 
-  subroutine gronor_worker_process()
+  subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   use mpi
   use cidef
@@ -272,7 +277,25 @@ contains
 
   implicit none
 
+  real (kind=8), intent(inout) :: va(:,:),vb(:,:),tb(:,:),ta(:,:),a(:,:)
+  real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
+  real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
+  real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
+
 !  external :: MPI_Recv,MPI_iRecv,MPI_iSend
+
+  thread_id = 0
+  lfnmpi    = 0
+  mpifile   = ' '
+  ireq      = 0
+  ierr      = 0
+  ncount    = 0
+  mpitag    = 0
+  mpidest   = 0
+  ibuf      = 0_8
+  status    = 0
+  tbuf      = 0.0d0
+  flag      = .false.
 
   thread_id = omp_get_thread_num()
   if(idbg.gt.0) then
@@ -282,35 +305,6 @@ contains
     flush(lfndbg)
   endif
 
-  if(idbg.gt.50 .and. thread_id==0) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), " Array dimensions check:"
-    ! 输出二维数组维度
-    write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
-    write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
-    write(lfndbg,'(a,2i10)') " tb:    ", size(tb,1), size(tb,2)
-    write(lfndbg,'(a,2i10)') " ta:    ", size(ta,1), size(ta,2)
-    write(lfndbg,'(a,2i10)') " a:     ", size(a,1), size(a,2)
-    write(lfndbg,'(a,2i10)') " u:     ", size(u,1), size(u,2)
-    write(lfndbg,'(a,2i10)') " w:     ", size(w,1), size(w,2)
-    write(lfndbg,'(a,2i10)') " wt:    ", size(wt,1), size(wt,2)
-    write(lfndbg,'(a,2i10)') " sm:    ", size(sm,1), size(sm,2)
-    write(lfndbg,'(a,2i10)') " aaa:   ", size(aaa,1), size(aaa,2)
-    write(lfndbg,'(a,2i10)') " aat:   ", size(aat,1), size(aat,2)
-    write(lfndbg,'(a,2i10)') " tt:    ", size(tt,1), size(tt,2)
-    ! 输出一维数组维度
-    write(lfndbg,'(a,i10)')  " ev:    ", size(ev)
-    write(lfndbg,'(a,i10)')  " w1:    ", size(w1)
-    write(lfndbg,'(a,2i10)') " w2:    ", size(w2,1), size(w2,2)  ! 注意w2是二维
-    write(lfndbg,'(a,i10)')  " sdiag: ", size(sdiag)
-    write(lfndbg,'(a,i10)')  " diag:  ", size(diag)
-    write(lfndbg,'(a,i10)')  " bsdiag:", size(bsdiag)
-    write(lfndbg,'(a,i10)')  " bdiag: ", size(bdiag)
-    write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
-    write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
-    write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
-    flush(lfndbg)
-  endif
   if(thread_id.lt.0 .or. len_work_dbl.lt.0_8 .or. len_work_int.lt.0_8 .or.&
      me.lt.0 .or. mstr.lt.0) then
     write(*,'(a,5(1x,i0))') 'Error: invalid worker parameters', thread_id,&


### PR DESCRIPTION
## Summary
- Initialize thread and MPI-related locals to zero and output array dimensions and key scalars in `gronor_worker_process`
- Emit similar dimension diagnostics in `gronor_calculate` and `gronor_gnome`
- Record OpenMP thread IDs to restrict logging to a single thread

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_689243ecd3d8832a838aa82f9ded5cfd