### PR TITLE
Improve timestamp routine and expand debugging

### DIFF
--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -53,25 +53,70 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
   external :: swatch,timer_start,timer_stop
   external :: gronor_abort
 
-  integer (kind=4) :: ireq,ierr
-  integer (kind=4) :: iremote,status(MPI_STATUS_SIZE)
-  integer (kind=4) :: ncount,mpitag,mpidest
-  integer :: ib,jb,id1,id2,ii,ihc,nhc,iact
+  integer (kind=4) :: ireq=0,ierr=0
+  integer (kind=4) :: iremote=0,status(MPI_STATUS_SIZE)=0
+  integer (kind=4) :: ncount=0,mpitag=0,mpidest=0
+  integer :: ib,jb,id1,id2,ii=0,ihc=0,nhc=0,iact=0
 
-  integer :: i,ibv,idet,ij,j,k,l2,m,nop,nvc,indxx
-  integer :: idown,iup,iv,ncleff,nopeff,mspin,iclose,nb,ncl,indexv
-  integer :: ntvc,ivc,ibas
+  integer :: i=0,ibv=0,idet=0,ij=0,j=0,k=0,l2=0,m=0,nop=0,nvc=0,indxx=0
+  integer :: idown=0,iup=0,iv=0,ncleff=0,nopeff=0,mspin=0,iclose=0,nb=0,ncl=0,indexv=0
+  integer :: ntvc=0,ivc=0,ibas=0
 
-  integer :: ioff
+  integer :: ioff=0
 
-  real (kind=8) :: btemp,btemp2
+  real (kind=8) :: btemp=0.0d0,btemp2=0.0d0
 
-  logical (kind=4) :: flag
+  logical (kind=4) :: flag=.false.
+
+  integer :: thread_id
+  character(len=10) :: today, now
+
+#ifdef _OPENMP
+  thread_id = omp_get_thread_num()
+#else
+  thread_id = 0
+#endif
 
   ndeti=idetb(ib)
   ndetj=idetb(jb)
   nacti=nactb(ib)
   nactj=nactb(jb)
+
+  if(idbg.gt.10 .and. thread_id==0) then
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8), " Array dimensions check in gronor_calculate:"
+    write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
+    write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
+    write(lfndbg,'(a,2i10)') " tb:    ", size(tb,1), size(tb,2)
+    write(lfndbg,'(a,2i10)') " ta:    ", size(ta,1), size(ta,2)
+    write(lfndbg,'(a,2i10)') " a:     ", size(a,1), size(a,2)
+    write(lfndbg,'(a,2i10)') " u:     ", size(u,1), size(u,2)
+    write(lfndbg,'(a,2i10)') " w:     ", size(w,1), size(w,2)
+    write(lfndbg,'(a,2i10)') " wt:    ", size(wt,1), size(wt,2)
+    write(lfndbg,'(a,2i10)') " sm:    ", size(sm,1), size(sm,2)
+    write(lfndbg,'(a,2i10)') " aaa:   ", size(aaa,1), size(aaa,2)
+    write(lfndbg,'(a,2i10)') " aat:   ", size(aat,1), size(aat,2)
+    write(lfndbg,'(a,2i10)') " tt:    ", size(tt,1), size(tt,2)
+    write(lfndbg,'(a,i10)')  " ev:    ", size(ev)
+    write(lfndbg,'(a,i10)')  " w1:    ", size(w1)
+    write(lfndbg,'(a,2i10)') " w2:    ", size(w2,1), size(w2,2)
+    write(lfndbg,'(a,i10)')  " sdiag: ", size(sdiag)
+    write(lfndbg,'(a,i10)')  " diag:  ", size(diag)
+    write(lfndbg,'(a,i10)')  " bsdiag:", size(bsdiag)
+    write(lfndbg,'(a,i10)')  " bdiag: ", size(bdiag)
+    write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
+    write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
+    write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
+    write(lfndbg,'(a,i10)')  " ib:    ", ib
+    write(lfndbg,'(a,i10)')  " jb:    ", jb
+    write(lfndbg,'(a,i10)')  " id1:   ", id1
+    write(lfndbg,'(a,i10)')  " id2:   ", id2
+    write(lfndbg,'(a,i10)')  " ndeti: ", ndeti
+    write(lfndbg,'(a,i10)')  " ndetj: ", ndetj
+    write(lfndbg,'(a,i10)')  " nacti: ", nacti
+    write(lfndbg,'(a,i10)')  " nactj: ", nactj
+    flush(lfndbg)
+  endif
   if(idbg.ge.50) then
     write(lfndbg,600) ib,jb,id1,id2
 600 format(/,20('*'),' ',i5,' -',i5,' : ',i5,' -',i5,' ',20('*'))
@@ -128,8 +173,8 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
 
       if(flag) then
         if(idbg.gt.10) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8),' Terminating in gronor_calculate'
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8),' Terminating in gronor_calculate'
         endif
         oterm=.true.
         return
@@ -365,8 +410,8 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
         endif
       endif
       if(idbg.ge.12) then
-        call swatch(date,time)
-        write(lfndbg,651) date(1:8),time(1:8),ij,i,j,hh,ss
+        call swatch(today,now)
+        write(lfndbg,651) today(1:8),now(1:8),ij,i,j,hh,ss
 651     format(a,1x,a,' Calculated values from gronor_gnome ',3i7,'  H:',f20.10,'  S:',f20.10)
       endif
       buffer(1)=buffer(1)+fac*civb(i,ib)*civb(j,jb)*hh
@@ -417,8 +462,8 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
         call MPI_Recv(e2summ,ncount,MPI_REAL8,MPI_ANY_SOURCE,mpitag,MPI_COMM_WORLD,status,ierr)
         iremote=status(MPI_SOURCE)
         if(idbg.gt.10) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,i5,a,i5)') date(1:8),time(1:8),me,' received e2buf from',iremote
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,i5,a,i5)') today(1:8),now(1:8),me,' received e2buf from',iremote
           flush(lfndbg)
         endif
         e2buff=e2buff+e2summ
@@ -430,8 +475,8 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
       call MPI_iSend(e2buff,ncount,MPI_REAL8,mpidest,mpitag,MPI_COMM_WORLD,ireq,ierr)
       call MPI_Request_free(ireq,ierr)
       if(idbg.gt.10) then
-        call swatch(date,time)
-        write(lfndbg,'(a,1x,a,i5,a,i5)') date(1:8),time(1:8),me,' sent e2buf to',thisgroup(2)
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,i5,a,i5)') today(1:8),now(1:8),me,' sent e2buf to',thisgroup(2)
         flush(lfndbg)
       endif
 

--- a/src/gnome/gronor_cml.F90
+++ b/src/gnome/gronor_cml.F90
@@ -82,6 +82,7 @@ subroutine gronor_env_cml(version,version_type)
   character(len=132)  :: info_cml
   integer             :: indent
   integer,external    :: getcpucount
+  character(len=10)   :: today, now
 
   ! Open the calculation
   label='module'
@@ -157,8 +158,8 @@ subroutine gronor_env_cml(version,version_type)
   info_cml='empty'
   call writetag_scalar_integer(lfncml,info_cml,6,ntask)
   call close_tag(lfncml,label,5)
-  call swatch(date,time)
-  runDate=date(1:8)//'  '//time(1:8)
+  call swatch(today,now)
+  runDate=today(1:8)//'  '//now(1:8)
   info_cml='dictRef="cc:runDate"'
   call open_tag(lfncml,label,info_cml,5)
   info_cml='empty'
@@ -354,6 +355,7 @@ subroutine gronor_finalize_cml
   character(len=20)    :: label
   character(len=18)    :: stopDate
   real(kind=8), external :: timer_wall_total
+  character(len=10)    :: today, now
 
   label='module'
   indent=3
@@ -366,8 +368,8 @@ subroutine gronor_finalize_cml
   info_cml='empty'
   call open_tag(lfncml,label,info_cml,indent)
   label='property'
-  call swatch(date,time)
-  stopDate=date(1:8)//'  '//time(1:8)
+  call swatch(today,now)
+  stopDate=today(1:8)//'  '//now(1:8)
   info_cml='dictRef="cc:jobdatetime.end"'
   call open_tag(lfncml,label,info_cml,5)
   info_cml='empty'

--- a/src/gnome/gronor_cofac1.F90
+++ b/src/gnome/gronor_cofac1.F90
@@ -25,6 +25,7 @@
       use gnome_parameters
       use gnome_data
       use gnome_solvers
+      use omp_lib
       implicit none
       contains
       subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
@@ -43,7 +44,31 @@
       real (kind=8) :: coef
       real (kind=8) :: cmax, cnorm, coefu
       integer :: nz1, nz2
+      integer :: thread_id
+      character(len=10) :: today, now
 
+
+      thread_id = omp_get_thread_num()
+      if(idbg.gt.10 .and. thread_id==0) then
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8), &
+             ' Array dimensions check in gronor_cofac1:'
+        write(lfndbg,'(a,2i10)') ' a:     ', size(a,1), size(a,2)
+        write(lfndbg,'(a,2i10)') ' u:     ', size(u,1), size(u,2)
+        write(lfndbg,'(a,2i10)') ' w:     ', size(w,1), size(w,2)
+        write(lfndbg,'(a,2i10)') ' wt:    ', size(wt,1), size(wt,2)
+        write(lfndbg,'(a,2i10)') ' ta:    ', size(ta,1), size(ta,2)
+        write(lfndbg,'(a,1i10)') ' ev:    ', size(ev)
+        write(lfndbg,'(a,1i10)') ' diag:  ', size(diag)
+        write(lfndbg,'(a,1i10)') ' sdiag: ', size(sdiag)
+        write(lfndbg,'(a,1i10)') ' cdiag: ', size(cdiag)
+        write(lfndbg,'(a,1i10)') ' csdiag:', size(csdiag)
+        write(lfndbg,'(a,5i10)') ' scalars nelecs mbasel ntcla ntclb nveca:', &
+             nelecs, mbasel, ntcla, ntclb, nveca
+        write(lfndbg,'(a,1x,es12.4)') ' a(1,1)=', a(1,1)
+        write(lfndbg,'(a,1x,es12.4)') ' u(1,1)=', u(1,1)
+        write(lfndbg,'(a,1x,es12.4)') ' w(1,1)=', w(1,1)
+      end if
 
       if(idbg.ge.30) write(lfndbg,600)
  600  format(/,' Cofactor matrix will be calculated')

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -26,6 +26,9 @@ module gronor_gnome_mod
   use gnome_integrals
   use gnome_parameters
   use gnome_data
+#ifdef _OPENMP
+  use omp_lib
+#endif
   use gronor_moover_mod,    only: gronor_moover
   use gronor_cofac1_mod,    only: gronor_cofac1
   use gronor_cororb_mod,    only: gronor_cororb
@@ -48,12 +51,22 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   external :: gronor_abort
   external :: gronor_tranout
   external :: gronor_transvc
+  external :: swatch
 
-  integer :: lfndbg,idet,k,iv,ib,ihc,nhc,ntvc,ivc,ibas
+  integer :: lfndbg,ihc,nhc
+  integer :: idet=0,k=0,iv=0,ib=0,ntvc=0,ivc=0,ibas=0
 
-  logical (kind=4) :: flag
-  integer (kind=4) :: ierr,status(MPI_STATUS_SIZE)
+  logical (kind=4) :: flag=.false.
+  integer (kind=4) :: ierr=0,status(MPI_STATUS_SIZE)=0
 
+  integer :: thread_id
+  character(len=10) :: today, now
+
+#ifdef _OPENMP
+  thread_id = omp_get_thread_num()
+#else
+  thread_id = 0
+#endif
 
   e1=0.0d0
   e2=0.0d0
@@ -118,6 +131,40 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   n1bas=nbas*(nbas+1)/2
   nstdim=max(1,nelecs*nelecs,n1bas)
   mbasel=max(nelecs,nbas)
+
+  if(idbg.gt.10 .and. thread_id==0) then
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8), " Array dimensions check in gronor_gnome:"
+    write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
+    write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
+    write(lfndbg,'(a,2i10)') " tb:    ", size(tb,1), size(tb,2)
+    write(lfndbg,'(a,2i10)') " ta:    ", size(ta,1), size(ta,2)
+    write(lfndbg,'(a,2i10)') " a:     ", size(a,1), size(a,2)
+    write(lfndbg,'(a,2i10)') " u:     ", size(u,1), size(u,2)
+    write(lfndbg,'(a,2i10)') " w:     ", size(w,1), size(w,2)
+    write(lfndbg,'(a,2i10)') " wt:    ", size(wt,1), size(wt,2)
+    write(lfndbg,'(a,2i10)') " sm:    ", size(sm,1), size(sm,2)
+    write(lfndbg,'(a,2i10)') " aaa:   ", size(aaa,1), size(aaa,2)
+    write(lfndbg,'(a,2i10)') " aat:   ", size(aat,1), size(aat,2)
+    write(lfndbg,'(a,2i10)') " tt:    ", size(tt,1), size(tt,2)
+    write(lfndbg,'(a,i10)')  " ev:    ", size(ev)
+    write(lfndbg,'(a,i10)')  " w1:    ", size(w1)
+    write(lfndbg,'(a,2i10)') " w2:    ", size(w2,1), size(w2,2)
+    write(lfndbg,'(a,i10)')  " sdiag: ", size(sdiag)
+    write(lfndbg,'(a,i10)')  " diag:  ", size(diag)
+    write(lfndbg,'(a,i10)')  " bsdiag:", size(bsdiag)
+    write(lfndbg,'(a,i10)')  " bdiag: ", size(bdiag)
+    write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
+    write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
+    write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
+    write(lfndbg,'(a,i10)')  " ihc:   ", ihc
+    write(lfndbg,'(a,i10)')  " nhc:   ", nhc
+    write(lfndbg,'(a,i10)')  " nveca: ", nveca
+    write(lfndbg,'(a,i10)')  " nvecb: ", nvecb
+    write(lfndbg,'(a,i10)')  " nelecs:", nelecs
+    write(lfndbg,'(a,i10)')  " mbasel:", mbasel
+    flush(lfndbg)
+  endif
 
   if(nveca.ne.ntcl(1)+ntop(1)) call gronor_abort(306,"Incompatible nveca")
   if(nvecb.ne.ntcl(2)+ntop(2)) call gronor_abort(307,"Incompatible nvecb")

--- a/src/gnome/gronor_main.F90
+++ b/src/gnome/gronor_main.F90
@@ -98,6 +98,7 @@ subroutine gronor_main()
   real (kind=8) :: rdum(6)
   character (len=255) :: string,architecture,compiler
   logical exist,first_pass
+  character(len=10) :: today, now
 
   real(kind=8), external :: timer_wall_total
 
@@ -173,7 +174,7 @@ subroutine gronor_main()
     l2=len(trim(host))
     if(n.gt.0.and.n.lt.l2) write(host,'(a)') host(n+1:l2)
 
-    call swatch(date,time)
+    call swatch(today,now)
     call getcwd(cwd)
 
     !     Read a single string argument 'root' from the command line, that
@@ -246,8 +247,8 @@ subroutine gronor_main()
     call gronor_prelude_cml()
 
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99),'  :  Start of job'
+    call swatch(today,now)
+    write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99),'  :  Start of job'
 702 format(a8,2x,a8,f12.3,a)
     flush(lfnday)
     call timer_start(99)
@@ -485,7 +486,7 @@ subroutine gronor_main()
 #if defined(GPUAMD) || defined(GPUNVIDIA)
     if(ipr.ge.20) write(lfnout,601) trim(user),getcpucount(), &
         trim(host),onlabel,trim(machine),nnodes, &
-        date(1:8),time(1:8),nrsets, &
+        today(1:8),now(1:8),nrsets, &
         nrnsets,numdev,ngpus,nummps, &
         np,np/nnodes,np/nrsets, &
         ncycls,num_threads
@@ -506,7 +507,7 @@ subroutine gronor_main()
 #else
     if(ipr.ge.20) write(lfnout,601) trim(user),getcpucount(), &
         trim(host),onlabel,trim(machine),nnodes, &
-        date(1:8),time(1:8),np,np/nnodes,ncycls,num_threads
+        today(1:8),now(1:8),np,np/nnodes,ncycls,num_threads
 601 format(//, &
         ' User',t30,a,t60,'CPU count',t100,i10,/,/, &
         ' Host',t30,a,a,a,t60,'Number of nodes',t100,i10,/, &
@@ -559,7 +560,7 @@ subroutine gronor_main()
         ' CI vector file(s) are',t25,a,a,'_lbl.det',/ &
         ' MO vector file(s) are',t25,a,a,'_lbl.vec')
 
-    call swatch(date,time)
+    call swatch(today,now)
     write(lfnarx,401) trim(user)
     write(lfnxrx,401) trim(user)
 401 format('User ',a)
@@ -806,8 +807,8 @@ subroutine gronor_main()
 
     if(me.eq.mstr) then
       call timer_stop(99)
-      call swatch(date,time)
-      write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99),'  :  Input broadcasted'
+      call swatch(today,now)
+      write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99),'  :  Input broadcasted'
       flush(lfnday)
       call timer_start(99)
     endif
@@ -1376,8 +1377,8 @@ subroutine gronor_main()
         !     istat=cudaMemGetInfo(cpfre,cptot)
         memavail=memfre
         if(idbg.gt.0) then
-          call swatch(date,time)
-          write(lfndbg,1301) date(1:8),time(1:8),' Device set to ',mydev,' of ',numdev
+          call swatch(today,now)
+          write(lfndbg,1301) today(1:8),now(1:8),' Device set to ',mydev,' of ',numdev
 1301      format(a,1x,a,1x,a,i3,a,i3)
           flush(lfndbg)
         endif
@@ -1500,8 +1501,8 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,1707) date(1:8),time(1:8),timer_wall_total(99), &
+    call swatch(today,now)
+    write(lfnday,1707) today(1:8),now(1:8),timer_wall_total(99), &
         '  :  Start of base state generation'
 1707 format(a8,2x,a8,f12.3,a)
     flush(lfnday)
@@ -1516,8 +1517,8 @@ subroutine gronor_main()
   do i=1,nbase
 
     if(idbg.ge.50) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a,i4)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a,i4)') today(1:8),now(1:8), &
           ' entering make_basestate for ibase ',i
       flush(lfndbg)
     endif
@@ -1525,16 +1526,16 @@ subroutine gronor_main()
     call gronor_make_basestate(i,first_pass)
 
     if(idbg.ge.50) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a,i4)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a,i4)') today(1:8),now(1:8), &
           ' returned from make_basestate for ibase ',i
       flush(lfndbg)
     endif
 
     if(me.eq.mstr) then
       call timer_stop(99)
-      call swatch(date,time)
-      write(lfnday,1706) date(1:8),time(1:8),timer_wall_total(99), &
+      call swatch(today,now)
+      write(lfnday,1706) today(1:8),now(1:8),timer_wall_total(99), &
           '  :  First pass for base state  ',i,' completed '
 1706  format(a8,2x,a8,f12.3,a,i4,a)
       flush(lfnday)
@@ -1542,8 +1543,8 @@ subroutine gronor_main()
     endif
 
     if(idbg.ge.50) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a,i4)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a,i4)') today(1:8),now(1:8), &
           ' Base state completed for ibase ',i
       flush(lfndbg)
     endif
@@ -1558,8 +1559,8 @@ subroutine gronor_main()
   do i=1,nbase
 
     if(idbg.ge.50) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a,i4)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a,i4)') today(1:8),now(1:8), &
           ' entering make_basestate for ibase ',i
       flush(lfndbg)
     endif
@@ -1567,24 +1568,24 @@ subroutine gronor_main()
     call gronor_make_basestate(i,first_pass)
 
     if(idbg.ge.50) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a,i4)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a,i4)') today(1:8),now(1:8), &
           ' returned from make_basestate for ibase ',i
       flush(lfndbg)
     endif
 
     if(me.eq.mstr) then
       call timer_stop(99)
-      call swatch(date,time)
-      write(lfnday,1706) date(1:8),time(1:8),timer_wall_total(99), &
+      call swatch(today,now)
+      write(lfnday,1706) today(1:8),now(1:8),timer_wall_total(99), &
           '  :  Second pass for base state ',i,' completed '
       flush(lfnday)
       call timer_start(99)
     endif
 
     if(idbg.ge.50) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a,i4)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a,i4)') today(1:8),now(1:8), &
           ' Base state completed for ibase ',i
       flush(lfndbg)
     endif
@@ -1623,8 +1624,8 @@ subroutine gronor_main()
     idetb(ibase)=ndet_rev
     if(me.eq.mstr) then
       call timer_stop(99)
-      call swatch(date,time)
-      write(lfnday,1710) date(1:8),time(1:8),timer_wall_total(99), &
+      call swatch(today,now)
+      write(lfnday,1710) today(1:8),now(1:8),timer_wall_total(99), &
           '  :  Base state ',ibase, &
           ' coefficient list reduced from    ', &
           alldets(ibase),' to ',ndet_rev
@@ -1661,8 +1662,8 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,1708) date(1:8),time(1:8),timer_wall_total(99),'  :  Start of ME list generation'
+    call swatch(today,now)
+    write(lfnday,1708) today(1:8),now(1:8),timer_wall_total(99),'  :  Start of ME list generation'
 1708 format(a8,2x,a8,f12.3,a)
     flush(lfnday)
     call timer_start(99)
@@ -1719,8 +1720,8 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,1703) date(1:8),time(1:8),timer_wall_total(99), &
+    call swatch(today,now)
+    write(lfnday,1703) today(1:8),now(1:8),timer_wall_total(99), &
         '  :  ME list dimension reduced from   ',ndtot,' to ',numdet
 1703 format(a8,2x,a8,f12.3,a,16x,i16,a,i16)
     flush(lfnday)
@@ -1769,8 +1770,8 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99),'  :  Base states generated'
+    call swatch(today,now)
+    write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99),'  :  Base states generated'
     flush(lfnday)
     call timer_start(99)
   endif
@@ -1853,8 +1854,8 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,1702) date(1:8),time(1:8),timer_wall_total(99),'  :  Start reading integrals'
+    call swatch(today,now)
+    write(lfnday,1702) today(1:8),now(1:8),timer_wall_total(99),'  :  Start reading integrals'
 1702 format(a8,2x,a8,f12.3,a)
     flush(lfnday)
     call timer_start(99)
@@ -1866,8 +1867,8 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99),'  :  Reading of integrals completed'
+    call swatch(today,now)
+    write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99),'  :  Reading of integrals completed'
     flush(lfnday)
     call timer_start(99)
   endif
@@ -1953,12 +1954,12 @@ subroutine gronor_main()
   call timer_start(4)
 
   if(idbg.gt.0) then
-    call swatch(date,time)
+    call swatch(today,now)
 #ifdef GPUAMD
-    write(lfndbg,'(a,1x,a,1x,a,11i5)') date(1:8),time(1:8), &
+    write(lfndbg,'(a,1x,a,1x,a,11i5)') today(1:8),now(1:8), &
         ' AMD    ',numdev,mydev,iamacc,nummps,numgpu,(map2(me+1,i),i=1,5)
 #else
-    write(lfndbg,'(a,1x,a,1x,a,11i5)') date(1:8),time(1:8), &
+    write(lfndbg,'(a,1x,a,1x,a,11i5)') today(1:8),now(1:8), &
         ' NVIDIA ',numdev,mydev,iamacc,nummps,numgpu,(map2(me+1,i),i=1,5)
 #endif
     flush(lfndbg)
@@ -1966,16 +1967,16 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     if(idbg.gt.0) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a)') date(1:8),time(1:8),' Calling GronOR_master'
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a)') today(1:8),now(1:8),' Calling GronOR_master'
       flush(lfndbg)
     endif
     call gronor_memory_usage()
     call gronor_master()
   else
     if(idbg.gt.0) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,1x,a,2i5)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,1x,a,2i5)') today(1:8),now(1:8), &
  &         ' iamactive, iamacc=',iamactive,iamacc
       flush(lfndbg)
     endif
@@ -2016,15 +2017,15 @@ subroutine gronor_main()
 
       if(iamacc.eq.1) then
         if(idbg.gt.0) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,1x,a,i12)') date(1:8),time(1:8),' mint2= ',mint2
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,1x,a,i12)') today(1:8),now(1:8),' mint2= ',mint2
           flush(lfndbg)
         endif
 
 !$acc data copyin(g,lab,ndx,t,v,dqm,ndxtv,s)
         if(idbg.gt.0) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,1x,a)') date(1:8),time(1:8),' Calling GronOR_worker'
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,1x,a)') today(1:8),now(1:8),' Calling GronOR_worker'
           flush(lfndbg)
         endif
         call gronor_memory_usage()
@@ -2109,7 +2110,7 @@ subroutine gronor_main()
     inquire(file=trim(fillog),exist=EXIST)
     open(unit=lfnlog,file=trim(fillog),form='formatted',status='unknown',position='append',err=993)
     call timer_stop(99)
-    call swatch(date,time)
+    call swatch(today,now)
     if(.not.exist) then
       write(lfnlog,800)
 800   format( &
@@ -2126,7 +2127,7 @@ subroutine gronor_main()
           '  User',t12,'Jobname',t35,'Command',t45,'tau_MO   tau_CI   tau_CI_off', &
           ' Wspc svd  Wspc evd     Tasks',/)
     endif
-    write(lfnlog,801) date(1:8),time(1:8), &
+    write(lfnlog,801) today(1:8),now(1:8), &
         timer_wall_total(99)-timer_wall_total(98), &
         timer_wall_total(98),timer_wall_total(99), &
         nnodes,np,numacc,numnon,nummps,numgpu,num_threads,mgr, &
@@ -2197,8 +2198,8 @@ subroutine gronor_main()
 
   if(me.eq.mstr) then
     call timer_stop(99)
-    call swatch(date,time)
-    write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99), &
+    call swatch(today,now)
+    write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99), &
         '  :  End of Hamiltonian calculation'
     flush(lfnday)
     call timer_start(99)
@@ -2279,7 +2280,7 @@ subroutine gronor_main()
         write(lfndbg,'(a)') "Issuing mpi_abort"
         flush(lfndbg)
       endif
-      call swatch(date,time)
+      call swatch(today,now)
       if(ipr.ge.0) write(lfnout,637) trim(date),trim(time)
 637   format(/,' Completion/abort of run ',2a10,/)
       flush(lfnout)
@@ -2289,12 +2290,12 @@ subroutine gronor_main()
       if(idbg.gt.0) then
         write(lfndbg,'(a)') "Issuing mpi_finalize"
         flush(lfndbg)
-        call swatch(date,time)
-        write(lfndbg,'(a,1x,a,a,a)') date(1:8),time(1:8),' Closing ',trim(fildbg)
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,a,a)') today(1:8),now(1:8),' Closing ',trim(fildbg)
         flush(lfndbg)
         close(unit=lfndbg,status='keep')
       endif
-      call swatch(date,time)
+      call swatch(today,now)
       if(ipr.ge.0) write(lfnout,638) trim(date),trim(time)
 638   format(/,' Completion/finalize of run ',2a10,/)
       flush(lfnout)

--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -64,6 +64,7 @@ subroutine gronor_master()
   integer (kind=4):: status(MPI_STATUS_SIZE)
   integer (kind=4):: err_len, ierr_abort
   character(len=MPI_MAX_ERROR_STRING) :: err_msg
+  character(len=10) :: today, now
 
   real(kind=8), external :: timer_wall_total
 
@@ -283,8 +284,8 @@ subroutine gronor_master()
         if(loada.gt.1.and.ntaska.gt.1) ntaska=max(1,ntaska/loada)
         if(load.gt.1.and.ntask.gt.1) ntask=max(1,ntask/load)
         call timer_stop(99)
-        call swatch(date,time)
-        write(lfnday,715) date(1:8),time(1:8),timer_wall_total(99), &
+        call swatch(today,now)
+        write(lfnday,715) today(1:8),now(1:8),timer_wall_total(99), &
             '  :  Applied load balancing factors',loada,load
 715     format(a8,2x,a8,f12.3,a,2i5)
         call timer_start(99)
@@ -329,14 +330,14 @@ subroutine gronor_master()
       endif
       flush(lfnout)
 
-      call swatch(date,time)
+      call swatch(today,now)
       call timer_stop(99)
       if(.not.ofirst) then
         if(ntasks(ibase,jbase).ne.-2) then
-          write(lfnday,802) date(1:8),time(1:8),timer_wall_total(99), &
+          write(lfnday,802) today(1:8),now(1:8),timer_wall_total(99), &
               '  :  ',ibase,jbase,' started   ',c2sum(ibase,jbase),nbdet(ibase,jbase),ndeti,ndetj
         else
-          write(lfnday,803) date(1:8),time(1:8), timer_wall_total(99), &
+          write(lfnday,803) today(1:8),now(1:8), timer_wall_total(99), &
               '  :  ',ibase,jbase,' read from checkpoint restart'
         endif
       endif
@@ -352,8 +353,8 @@ subroutine gronor_master()
       !     Loop over the number of determinant pairs for the current base pair
       
       if(idbg.gt.50) then
-        call swatch(date,time)
-        write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8)," Entering receive loop"
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8)," Entering receive loop"
         flush(lfndbg)
       endif
   
@@ -387,16 +388,16 @@ subroutine gronor_master()
         if(ofirst) then
           ofirst=.false.
           call timer_stop(99)
-          call swatch(date,time)
-          write(lfnday,705) date(1:8),time(1:8),timer_wall_total(99), &
+          call swatch(today,now)
+          write(lfnday,705) today(1:8),now(1:8),timer_wall_total(99), &
               '  :  Integral distribution completed'
-          write(lfnday,705) date(1:8),time(1:8),timer_wall_total(99), &
+          write(lfnday,705) today(1:8),now(1:8),timer_wall_total(99), &
               '  :  Start Hamiltonian calculation'
           if(ntasks(ibase,jbase).ne.-2) then
-            write(lfnday,802) date(1:8),time(1:8),timer_wall_total(99), &
+            write(lfnday,802) today(1:8),now(1:8),timer_wall_total(99), &
                 '  :  ',ibase,jbase,' started   ',c2sum(ibase,jbase),nbdet(ibase,jbase),ndeti,ndetj
           else
-            write(lfnday,803) date(1:8),time(1:8),timer_wall_total(99), &
+            write(lfnday,803) today(1:8),now(1:8),timer_wall_total(99), &
                 '  :  ',ibase,jbase,' read from checkpoint restart'
           endif
 705       format(a8,2x,a8,f12.3,a)
@@ -419,8 +420,8 @@ subroutine gronor_master()
         ltotal=ltotal+1
         
         if(idbg.gt.10) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,i5,a,7i7)') date(1:8),time(1:8), &
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,i5,a,7i7)') today(1:8),now(1:8), &
               mstr,' received buffer from',iremote,igrp,(lgroup(igrp,tid,i),i=1,5)
           flush(lfndbg)
         endif
@@ -442,25 +443,25 @@ subroutine gronor_master()
           !     Write entry to progress file
           
           if(ipro.eq.1.or.ipro.eq.3) then
-            call swatch(date,time)
+            call swatch(today,now)
             if(ipro.eq.1) rewind(unit=lfnpro)
-            write(lfnpro,680) date(1:8),time(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
+            write(lfnpro,680) today(1:8),now(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
                 lgroup(igrp,tid,4)-lgroup(igrp,tid,3)+1, &
               pnrb(ibin,jbin),buffer(1),buffer(2),(int(buffer(j)),j=4,8)
 680         format(a,1x,a,' Rcvd ',2i6,' : ',2i5,2i10,i6,f8.3,'% ',2e16.8,5i8)
             flush(lfnpro)
           elseif(ipro.eq.2.or.ipro.eq.4) then
-            call swatch(date,time)
+            call swatch(today,now)
             if(ipro.eq.2) rewind(unit=lfnpro)
-            write(lfnpro,681) date(1:8),time(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
+            write(lfnpro,681) today(1:8),now(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
                 lgroup(igrp,tid,4)-lgroup(igrp,tid,3)+1,pnrb(ibin,jbin)
 681         format(a,1x,a,' Rcvd ',2i6,' : ',2i5,2i10,i6,f8.3,'% ')
             flush(lfnpro)
           endif
           if(me.eq.mstr.and.pnrb(ibin,jbin).ge.fday(ibin,jbin)) then
             call timer_stop(99)
-            call swatch(date,time)
-            write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99),'  :  ',ibin,jbin,' at ', &
+            call swatch(today,now)
+            write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99),'  :  ',ibin,jbin,' at ', &
                 pnrb(ibin,jbin),'% ( ',ndets(ibin,jbin,2),' / ',ndets(ibin,jbin,1),' )'
 702         format(a8,2x,a8,f12.3,a,2i6,a,f5.1,a,i10,a,i10,a)
             flush(lfnday)
@@ -674,22 +675,22 @@ subroutine gronor_master()
 
             !     Write completion message to dayfile
 
-            call swatch(date,time)
+            call swatch(today,now)
             if(dabs(hbase(ibin,jbin)).lt.1.0e-05.or.dabs(sbase(ibin,jbin)).lt.1.0e-06) then
               if(ibin.ne.jbin) then
-                write(lfnday,703) date(1:8),time(1:8),timer_wall_total(99), &
+                write(lfnday,703) today(1:8),now(1:8),timer_wall_total(99), &
                     '  :  ',ibin,jbin,' completed, H,S   :',hbase(ibin,jbin),sbase(ibin,jbin)
               else
-                write(lfnday,703) date(1:8),time(1:8),timer_wall_total(99), &
+                write(lfnday,703) today(1:8),now(1:8),timer_wall_total(99), &
                     '  :  ',ibin,jbin,' completed, H,S,H*:', &
                     hbase(ibin,jbin),sbase(ibin,jbin),hbase(ibin,jbin)/sbase(ibin,jbin)
               endif
             else
               if(ibin.ne.jbin) then
-                write(lfnday,704) date(1:8),time(1:8),timer_wall_total(99), &
+                write(lfnday,704) today(1:8),now(1:8),timer_wall_total(99), &
                     '  :  ',ibin,jbin,' completed, H,S   :',hbase(ibin,jbin),sbase(ibin,jbin)
               else
-                write(lfnday,704) date(1:8),time(1:8),timer_wall_total(99), &
+                write(lfnday,704) today(1:8),now(1:8),timer_wall_total(99), &
                     '  :  ',ibin,jbin,' completed, H,S,H*:', &
                     hbase(ibin,jbin),sbase(ibin,jbin),hbase(ibin,jbin)/sbase(ibin,jbin)
               endif
@@ -780,8 +781,8 @@ subroutine gronor_master()
         !     Debug message
 
         if(idbg.gt.10) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,i5,a,7i7)') date(1:8),time(1:8), &
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,i5,a,7i7)') today(1:8),now(1:8), &
               mstr,' sent ibuf to        ',iremote,igrp,(ibuf(i),i=1,4)
           flush(lfndbg)
         endif
@@ -789,8 +790,8 @@ subroutine gronor_master()
         !     Progress entry
 
         if(ipr.eq.2.or.ipro.eq.4) then
-          call swatch(date,time)
-          write(lfnpro,682) date(1:8),time(1:8),iremote,igrp,(ibuf(j),j=1,4)
+          call swatch(today,now)
+          write(lfnpro,682) today(1:8),now(1:8),iremote,igrp,(ibuf(j),j=1,4)
 682       format(a,1x,a,' Sent ',2i6,' : ',2i5,2i10)
           flush(lfnpro)
         endif
@@ -816,9 +817,9 @@ subroutine gronor_master()
   !     Now the still outstanding tasks need to be collected
   !     Assuming that some may be unresponsive, duplicates of outstanding tasks are sent
 
-  call swatch(date,time)
+  call swatch(today,now)
   call timer_stop(99)
-  write(lfnday,8023) date(1:8),time(1:8),timer_wall_total(99),'  :  Switching to duplicate tasks'
+  write(lfnday,8023) today(1:8),now(1:8),timer_wall_total(99),'  :  Switching to duplicate tasks'
 8023 format(a8,2x,a8,f12.3,a)
   flush(lfnday)
   call timer_start(99)
@@ -878,8 +879,8 @@ subroutine gronor_master()
     lactive(igrp)=lactive(igrp)+1
 
     if(idbg.gt.10) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,i5,a,4i5)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,i5,a,4i5)') today(1:8),now(1:8), &
           mstr,' received last buffer from',iremote
       flush(lfndbg)
     endif
@@ -898,13 +899,13 @@ subroutine gronor_master()
 
       if(ipro.eq.1.or.ipro.eq.3) then
         if(ipro.eq.1) rewind(unit=lfnpro)
-        write(lfnpro,680) date(1:8),time(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
+        write(lfnpro,680) today(1:8),now(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
             lgroup(igrp,tid,4)-lgroup(igrp,tid,3)+1, &
             pnrb(ibin,jbin),buffer(1),buffer(2),(int(buffer(j)),j=4,8)
         flush(lfnpro)
       elseif(ipro.eq.2.or.ipro.eq.4) then
         if(ipro.eq.2) rewind(unit=lfnpro)
-        write(lfnpro,681) date(1:8),time(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
+        write(lfnpro,681) today(1:8),now(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
             lgroup(igrp,tid,4)-lgroup(igrp,tid,3)+1,pnrb(ibin,jbin)
         flush(lfnpro)
       endif
@@ -913,8 +914,8 @@ subroutine gronor_master()
       
       if(me.eq.mstr.and.pnrb(ibin,jbin).ge.fday(ibin,jbin)) then
         call timer_stop(99)
-        call swatch(date,time)
-        write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99),'  :  ',ibin,jbin,' at ', &
+        call swatch(today,now)
+        write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99),'  :  ',ibin,jbin,' at ', &
             pnrb(ibin,jbin),'% ( ',ndets(ibin,jbin,2),' / ',ndets(ibin,jbin,1),' )'
         flush(lfnday)
         call timer_start(99)
@@ -958,7 +959,7 @@ subroutine gronor_master()
       if(ntasks(ibin,jbin).eq.0) then
         call timer_stop(98)
         call timer_stop(99)
-        call swatch(date,time)
+        call swatch(today,now)
         if(ibin.eq.jbin) then
           ltemp=idetb(ibin)*(idetb(ibin)+1)/2
         else
@@ -1077,26 +1078,26 @@ subroutine gronor_master()
           flush(lfnout)
         endif
 
-        call swatch(date,time)
+        call swatch(today,now)
         write(lfncpr) ibin,jbin,hbase(ibin,jbin),sbase(ibin,jbin),tbase(ibin,jbin), &
             (nsing(ibin,jbin,k),k=1,4),(dqbase(ibin,jbin,k),k=1,9)
         flush(lfncpr)
 
         if(dabs(hbase(ibin,jbin)).lt.1.0e-05.or.dabs(sbase(ibin,jbin)).lt.1.0e-06) then
           if(ibin.ne.jbin) then
-            write(lfnday,703) date(1:8),time(1:8),timer_wall_total(99), &
+            write(lfnday,703) today(1:8),now(1:8),timer_wall_total(99), &
                 '  :  ',ibin,jbin,' completed, H,S   :',hbase(ibin,jbin),sbase(ibin,jbin)
           else
-            write(lfnday,703) date(1:8),time(1:8),timer_wall_total(99), &
+            write(lfnday,703) today(1:8),now(1:8),timer_wall_total(99), &
                 '  :  ',ibin,jbin,' completed, H,S,H*:', &
                 hbase(ibin,jbin),sbase(ibin,jbin),hbase(ibin,jbin)/sbase(ibin,jbin)
           endif
         else
           if(ibin.ne.jbin) then
-            write(lfnday,704) date(1:8),time(1:8),timer_wall_total(99), &
+            write(lfnday,704) today(1:8),now(1:8),timer_wall_total(99), &
                 '  :  ',ibin,jbin,' completed, H,S   :',hbase(ibin,jbin),sbase(ibin,jbin)
           else
-            write(lfnday,704) date(1:8),time(1:8),timer_wall_total(99), &
+            write(lfnday,704) today(1:8),now(1:8),timer_wall_total(99), &
                 '  :  ',ibin,jbin,' completed, H,S,H*:', &
                 hbase(ibin,jbin),sbase(ibin,jbin),hbase(ibin,jbin)/sbase(ibin,jbin)
           endif
@@ -1189,8 +1190,8 @@ subroutine gronor_master()
           !     Debug message
           
           if(idbg.gt.10) then
-            call swatch(date,time)
-            write(lfndbg,'(a,1x,a,i5,a,4i5)') date(1:8),time(1:8), &
+            call swatch(today,now)
+            write(lfndbg,'(a,1x,a,i5,a,4i5)') today(1:8),now(1:8), &
                 mstr,' sent duplicate ibuf to   ',iremote
             flush(lfndbg)
           endif
@@ -1198,8 +1199,8 @@ subroutine gronor_master()
           !     Progress entry
 
           if(ipro.eq.2.or.ipro.eq.4) then
-            call swatch(date,time)
-            write(lfnpro,682) date(1:8),time(1:8), &
+            call swatch(today,now)
+            write(lfnpro,682) today(1:8),now(1:8), &
                 iremote,igrp,(ibuf(k),k=1,4)
             flush(lfnpro)
           endif
@@ -1220,7 +1221,7 @@ subroutine gronor_master()
       !     Received data other than matrix elements, should currently be impossible
 
       if(ipro.eq.1.or.ipro.eq.3) then
-        write(lfnpro,683) date(1:8),time(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
+        write(lfnpro,683) today(1:8),now(1:8),iremote,igrp,(lgroup(igrp,tid,j),j=1,4), &
             lgroup(igrp,tid,4)-lgroup(igrp,tid,3)+1
 683     format(a,1x,a,' RCVD ',2i6,' : ',2i5,2i10,i6)
       endif
@@ -1249,8 +1250,8 @@ subroutine gronor_master()
   !     At this point all outstanding tasks have completed
 
   call timer_stop(99)
-  call swatch(date,time)
-  write(lfnday,706) date(1:8),time(1:8),timer_wall_total(99),'  :  Completed all tasks'
+  call swatch(today,now)
+  write(lfnday,706) today(1:8),now(1:8),timer_wall_total(99),'  :  Completed all tasks'
 706 format(a8,2x,a8,f12.3,a)
   flush(lfnday)
   call timer_start(99)
@@ -1306,8 +1307,8 @@ subroutine gronor_master()
       endif
 
       if(idbg.gt.10) then
-        call swatch(date,time)
-        write(lfndbg,'(a,1x,a,i5,a,2i5,a,4i5,i20)') date(1:8),time(1:8), &
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,i5,a,2i5,a,4i5,i20)') today(1:8),now(1:8), &
             mstr,' sent return to',iremote,mpitag,' buffer ',(itbuf(j,iremote+1),j=1,4),ireq2
         flush(lfndbg)
       endif
@@ -1340,8 +1341,8 @@ subroutine gronor_master()
           call MPI_Abort(MPI_COMM_WORLD, ierr, ierr_abort)
         endif
         if(idbg.gt.10) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,a,2i5,a,4i5,i20)') date(1:8),time(1:8), &
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,a,2i5,a,4i5,i20)') today(1:8),now(1:8), &
               ' Terminate signal sent to',iremote,mpitag,' buffer ',(itbuf(j,iremote+1),j=1,4),ireq9
         endif
       endif

--- a/src/gnome/gronor_memory_usage.F90
+++ b/src/gnome/gronor_memory_usage.F90
@@ -42,6 +42,7 @@ subroutine gronor_memory_usage()
   real (kind=8) ::gb
   integer (kind=4) :: ireq,ierr,istat(MPI_STATUS_SIZE)
   integer (kind=4) :: ncount,mpitag,mpisrc
+  character(len=10) :: today, now
 
   if(me.eq.0) then
     membuf(1)=mbasel
@@ -117,8 +118,8 @@ subroutine gronor_memory_usage()
   endif
 
   if(idbg.gt.50) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8)," Memory usage analysis completed"
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8)," Memory usage analysis completed"
     flush(lfndbg)
   endif
       

--- a/src/gnome/gronor_moover.F90
+++ b/src/gnome/gronor_moover.F90
@@ -25,6 +25,7 @@ module gronor_moover_mod
   use gnome_integrals
   use gnome_parameters
   use gnome_data
+  use omp_lib
   implicit none
 contains
 subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
@@ -38,6 +39,8 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
   integer :: lfndbg,i,nopala,nopalb,nalfab,i1,i2
   integer :: ib,kb,iv,ie,ke,le,kk,ii,k,l,m1
   real (kind=8) :: sum
+  integer :: thread_id
+  character(len=10) :: today, now
 
   if(idbg.ge.13) write(lfndbg,601)
 601 format(/,' Calculation of the overlap matrix')
@@ -60,7 +63,24 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
   if(idbg.ge.14) write(lfndbg,602)
 602 format('  itypen icentn jtype jcent   icount      indbas     ' &
         ,' indbas         overlap',//)
-  
+
+  thread_id = omp_get_thread_num()
+  if(idbg.gt.10 .and. thread_id==0) then
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8), &
+         ' Array dimensions check in gronor_moover:'
+    write(lfndbg,'(a,2i10)') ' va:    ', size(va,1), size(va,2)
+    write(lfndbg,'(a,2i10)') ' vb:    ', size(vb,1), size(vb,2)
+    write(lfndbg,'(a,2i10)') ' tb:    ', size(tb,1), size(tb,2)
+    write(lfndbg,'(a,2i10)') ' ta:    ', size(ta,1), size(ta,2)
+    write(lfndbg,'(a,2i10)') ' a:     ', size(a,1), size(a,2)
+    write(lfndbg,'(a,5i10)') ' nbas nelecs nveca nvecb nalfa:', &
+         nbas, nelecs, nveca, nvecb, nalfa
+    write(lfndbg,'(a,2i10)') ' ntcla ntclb:', ntcla, ntclb
+    write(lfndbg,'(a,1x,es12.4)') ' va(1,1)=', va(1,1)
+    write(lfndbg,'(a,1x,es12.4)') ' vb(1,1)=', vb(1,1)
+  end if
+
   ! Calculation of the overlap matrix ta from va, vb and s
 
 !$acc kernels present(ta,tb,s,vb)

--- a/src/gnome/gronor_parallel_integral_input.F90
+++ b/src/gnome/gronor_parallel_integral_input.F90
@@ -58,6 +58,7 @@ subroutine gronor_parallel_integral_input()
   integer (kind=8), allocatable :: nag(:),nig(:),nng(:)
   integer (kind=4) :: status(MPI_STATUS_SIZE)
   integer (kind=4) :: source
+  character(len=10) :: today, now
 
   inode=map2(me+1,6)
 
@@ -496,8 +497,8 @@ subroutine gronor_parallel_integral_input()
         endif
 
         if(idbg.gt.10) then
-          call swatch(date,time)
-          write(lfndbg,130) date(1:8),time(1:8),jint
+          call swatch(today,now)
+          write(lfndbg,130) today(1:8),now(1:8),jint
 130       format(a,1x,a,1x,' Integrals broadcasted for batch ',i5)
           flush(lfndbg)
         endif

--- a/src/gnome/gronor_solver_init.F90
+++ b/src/gnome/gronor_solver_init.F90
@@ -47,6 +47,7 @@ subroutine gronor_solver_init(ntemp,a,u,w,ev)
   integer, intent(in) :: ntemp
   real(kind=8) :: a(ntemp,ntemp),u(ntemp,ntemp),w(ntemp,ntemp),ev(ntemp)
   character(len=255) :: string
+  character(len=10) :: today, now
   
   integer (kind=8) :: lworki,lwork1m,lwork2m
   integer (kind=4) :: lwork1,lwork2
@@ -63,8 +64,8 @@ subroutine gronor_solver_init(ntemp,a,u,w,ev)
 ! Cusolver initialization for the svd
   
   if(idbg.gt.50) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a,2i4)') date(1:8),time(1:8)," Solver init for ",sv_solver,ev_solver
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a,2i4)') today(1:8),now(1:8)," Solver init for ",sv_solver,ev_solver
     flush(lfndbg)
   endif
 

--- a/src/gnome/gronor_timings.F90
+++ b/src/gnome/gronor_timings.F90
@@ -47,7 +47,7 @@ subroutine gronor_timings(lfnout,lfnday,lfntim)
   integer (kind=8) :: irtim,nreqso,nreqsc
   integer (kind=8) :: nrecav
   real (kind=8) :: recav
-  character (len=255) :: date,time
+  character (len=255) :: today, now
   logical (kind=4) :: flag
   logical :: openrcv
 
@@ -214,8 +214,8 @@ subroutine gronor_timings(lfnout,lfnday,lfntim)
       flush(lfnout)
 
       call timer_stop(99)
-      call swatch(date,time)
-      write(lfnday,706) date(1:8),time(1:8),timer_wall_total(99), &
+      call swatch(today,now)
+      write(lfnday,706) today(1:8),now(1:8),timer_wall_total(99), &
           '  :  Reported detailed timings analysis'
 706   format(a8,2x,a8,f12.3,a)
       flush(lfnday)
@@ -282,16 +282,16 @@ subroutine gronor_timings(lfnout,lfnday,lfntim)
           ' Total number of node-hours used',t55,f12.3)
       flush(lfnout)
     endif
-    call swatch(date,time)
-    write(lfnday,702) date(1:8),time(1:8),timer_wall_total(99), &
+    call swatch(today,now)
+    write(lfnday,702) today(1:8),now(1:8),timer_wall_total(99), &
         '  :  Reported timings summary'
 702 format(a8,2x,a8,f12.3,a)
     flush(lfnday)
-    call swatch(date,time)
-    write(lfnday,703) date(1:8),time(1:8),timer_wall_total(99),np, &
-        date(1:8),time(1:8),timer_wall_total(99),npg*mgr+1, &
-        date(1:8),time(1:8),timer_wall_total(99),nalive*mgr+1, &
-        date(1:8),time(1:8),timer_wall_total(99),numidle
+    call swatch(today,now)
+    write(lfnday,703) today(1:8),now(1:8),timer_wall_total(99),np, &
+        today(1:8),now(1:8),timer_wall_total(99),npg*mgr+1, &
+        today(1:8),now(1:8),timer_wall_total(99),nalive*mgr+1, &
+        today(1:8),now(1:8),timer_wall_total(99),numidle
 703 format(a8,2x,a8,f12.3,'  :  Completion of job with',t60,i8,' total ranks',/, &
         a8,2x,a8,f12.3,'  :',t60,i8,' assigned ranks',/, &
         a8,2x,a8,f12.3,'  :',t60,i8,' active ranks',/, &

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -48,6 +48,7 @@ subroutine gronor_worker()
   character(len=128) :: mpifile
   integer (kind=4) :: mpi_err_len, ierr2
   character(len=MPI_MAX_ERROR_STRING) :: mpi_err_str
+  character(len=10) :: today, now
 
   real (kind=8), allocatable :: va(:,:),vb(:,:),tb(:,:),ta(:,:),a(:,:)
   real (kind=8), allocatable :: u(:,:),w(:,:),wt(:,:),ev(:)
@@ -118,7 +119,7 @@ subroutine gronor_worker()
 
 !$omp parallel private(thread_id,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag, &
 !$omp& ibase,jbase,idet,jdet,nidet,njdet,i,j,k,l2,n,iact,ibuf,status,tbuf,lfnmpi,mpifile,ireq,ierr,ncount,mpitag,mpidest, &
-!$omp& mpi_err_len,ierr2,mpi_err_str,flag) &
+!$omp& mpi_err_len,ierr2,mpi_err_str,today,now,flag) &
 !$omp& copyin(oterm,otreq,odupl,itreq,irbuf,icur,jcur,lsvcpu,levcpu,lsvtrns, &
 !$omp&        ndeti,ndetj,nacti,nactj,inacti,inactj,nelecs,nveca,nvecb,nstdim,mbasel, &
 !$omp&        ntcl,ntop,nclose,nopen,nelec,nact,ninact)
@@ -162,22 +163,22 @@ subroutine gronor_worker()
 #endif
 
   if(idbg.gt.50 .and. thread_id==0) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8)," Entering solver initialization"
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8)," Entering solver initialization"
     flush(lfndbg)
   endif
 
   call gronor_solver_init(nelecs, a, u, w, ev)
 
   if(idbg.gt.50 .and. thread_id==0) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8)," Solver initialization completed"
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8)," Solver initialization completed"
     flush(lfndbg)
   endif
 
-  if(idbg.gt.50 .and. thread_id==0) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), " Array dimensions check:"
+  if(idbg.gt.10 .and. thread_id==0) then
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8), " Array dimensions check in gronor_worker_process:"
     ! 输出二维数组维度
     write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
     write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
@@ -202,11 +203,16 @@ subroutine gronor_worker()
     write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
     write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
     write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
+    write(lfndbg,'(a,i10)')  " nelecs:", nelecs
+    write(lfndbg,'(a,i10)')  " nveca: ", nveca
+    write(lfndbg,'(a,i10)')  " nvecb: ", nvecb
+    write(lfndbg,'(a,i10)')  " mbasel:", mbasel
+    write(lfndbg,'(a,i10)')  " nstdim:", nstdim
     flush(lfndbg)
   endif
 
 
-  call gronor_worker_process()
+  call gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   call gronor_solver_finalize()
 
@@ -259,7 +265,7 @@ subroutine gronor_worker()
 
 contains
 
-  subroutine gronor_worker_process()
+  subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
 
   use mpi
   use cidef
@@ -272,7 +278,25 @@ contains
 
   implicit none
 
+  real (kind=8), intent(inout) :: va(:,:),vb(:,:),tb(:,:),ta(:,:),a(:,:)
+  real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
+  real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
+  real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
+
 !  external :: MPI_Recv,MPI_iRecv,MPI_iSend
+
+  thread_id = 0
+  lfnmpi    = 0
+  mpifile   = ' '
+  ireq      = 0
+  ierr      = 0
+  ncount    = 0
+  mpitag    = 0
+  mpidest   = 0
+  ibuf      = 0_8
+  status    = 0
+  tbuf      = 0.0d0
+  flag      = .false.
 
   thread_id = omp_get_thread_num()
   if(idbg.gt.0) then
@@ -282,35 +306,6 @@ contains
     flush(lfndbg)
   endif
 
-  if(idbg.gt.50 .and. thread_id==0) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), " Array dimensions check:"
-    ! 输出二维数组维度
-    write(lfndbg,'(a,2i10)') " va:    ", size(va,1), size(va,2)
-    write(lfndbg,'(a,2i10)') " vb:    ", size(vb,1), size(vb,2)
-    write(lfndbg,'(a,2i10)') " tb:    ", size(tb,1), size(tb,2)
-    write(lfndbg,'(a,2i10)') " ta:    ", size(ta,1), size(ta,2)
-    write(lfndbg,'(a,2i10)') " a:     ", size(a,1), size(a,2)
-    write(lfndbg,'(a,2i10)') " u:     ", size(u,1), size(u,2)
-    write(lfndbg,'(a,2i10)') " w:     ", size(w,1), size(w,2)
-    write(lfndbg,'(a,2i10)') " wt:    ", size(wt,1), size(wt,2)
-    write(lfndbg,'(a,2i10)') " sm:    ", size(sm,1), size(sm,2)
-    write(lfndbg,'(a,2i10)') " aaa:   ", size(aaa,1), size(aaa,2)
-    write(lfndbg,'(a,2i10)') " aat:   ", size(aat,1), size(aat,2)
-    write(lfndbg,'(a,2i10)') " tt:    ", size(tt,1), size(tt,2)
-    ! 输出一维数组维度
-    write(lfndbg,'(a,i10)')  " ev:    ", size(ev)
-    write(lfndbg,'(a,i10)')  " w1:    ", size(w1)
-    write(lfndbg,'(a,2i10)') " w2:    ", size(w2,1), size(w2,2)  ! 注意w2是二维
-    write(lfndbg,'(a,i10)')  " sdiag: ", size(sdiag)
-    write(lfndbg,'(a,i10)')  " diag:  ", size(diag)
-    write(lfndbg,'(a,i10)')  " bsdiag:", size(bsdiag)
-    write(lfndbg,'(a,i10)')  " bdiag: ", size(bdiag)
-    write(lfndbg,'(a,i10)')  " csdiag:", size(csdiag)
-    write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
-    write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
-    flush(lfndbg)
-  endif
   if(thread_id.lt.0 .or. len_work_dbl.lt.0_8 .or. len_work_int.lt.0_8 .or.&
      me.lt.0 .or. mstr.lt.0) then
     write(*,'(a,5(1x,i0))') 'Error: invalid worker parameters', thread_id,&
@@ -333,11 +328,11 @@ contains
   size(tb,1),size(tb,2),size(ta,1),size(ta,2),size(a,1),size(a,2)
   
   if(idbg.gt.0) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,1x,a,5i5)') date(1:8),time(1:8), &
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,1x,a,5i5)') today(1:8),now(1:8), &
         ' iamhead, numdev, master, mygroup =',iamhead,numdev,mstr,mygroup
-    call swatch(date,time)
-    write(lfndbg,130) date(1:8),time(1:8),' thisgroup=',(thisgroup(i),i=1,mgr+1)
+    call swatch(today,now)
+    write(lfndbg,130) today(1:8),now(1:8),' thisgroup=',(thisgroup(i),i=1,mgr+1)
 130 format(a,1x,a,1x,a,t30,11i5,/,(t35,10i5))
     flush(lfndbg)
   endif
@@ -362,13 +357,13 @@ contains
   endif
   write(lfnmpi,'("send ready len_work_dbl=",i0," len_work_int=",i0)') int(tbuf(16)),int(tbuf(17))
   if(idbg.gt.20) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,1x,a)') date(1:8),time(1:8),' Head signalled master'
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,1x,a)') today(1:8),now(1:8),' Head signalled master'
     flush(lfndbg)
   endif
   if(idbg.gt.10) then
-    call swatch(date,time)
-    write(lfndbg,'(a,1x,a,i5,a,4i7)') date(1:8),time(1:8),me,' sent buffer   ',mstr
+    call swatch(today,now)
+    write(lfndbg,'(a,1x,a,i5,a,4i7)') today(1:8),now(1:8),me,' sent buffer   ',mstr
     flush(lfndbg)
   endif
 
@@ -391,8 +386,8 @@ contains
     write(lfnmpi,'("recv task ibuf=",4i12)') ibuf
 
     if(idbg.gt.10) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,i5,a,7i7)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,i5,a,7i7)') today(1:8),now(1:8), &
           me,' received task ',mstr,mpitag,(ibuf(i),i=1,4),ierr
       flush(lfndbg)
     endif
@@ -457,9 +452,9 @@ contains
         endif
         !            call MPI_Request_free(itreq,ierr)
         if(idbg.gt.10) then
-          call swatch(date,time)
+          call swatch(today,now)
           write(lfndbg,'(a,1x,a,a)') &
-              date(1:8),time(1:8),' Terminate iRecv posted '
+              today(1:8),now(1:8),' Terminate iRecv posted '
         endif
         otreq=.true.
       endif
@@ -473,8 +468,8 @@ contains
       if(flag) then
 !            call MPI_Cancel(itreq,ierr)
         if(idbg.gt.10) then
-          call swatch(date,time)
-          write(lfndbg,'(a,1x,a,a)') date(1:8),time(1:8), &
+          call swatch(today,now)
+          write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8), &
               ' Terminating in gronor_worker'
         endif
         call timer_stop(39)
@@ -487,8 +482,8 @@ contains
     call timer_stop(39)
     
     if(idbg.gt.15) then
-      call swatch(date,time)
-      write(lfndbg,'(a,1x,a,a,f12.6)') date(1:8),time(1:8), &
+      call swatch(today,now)
+      write(lfndbg,'(a,1x,a,a,f12.6)') today(1:8),now(1:8), &
           ' Cumulative COMM1 Wait Time ',timer_wall_total(39)
       flush(lfndbg)
     endif
@@ -501,8 +496,8 @@ contains
     call timer_start(46)
     if(ibase.ne.0.and..not.oterm) then
       if(idbg.gt.30) then
-        call swatch(date,time)
-        write(lfndbg,'(a,1x,a,i5,a,6i10)') date(1:8),time(1:8), &
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,i5,a,6i10)') today(1:8),now(1:8), &
             me,' Entering gronor_calculate with ',ibase,jbase,idet,jdet,ntask,nbatch
         flush(lfndbg)
       endif
@@ -522,8 +517,8 @@ contains
       
       buffer(3)=timer_wall(47)
       if(idbg.gt.30) then
-        call swatch(date,time)
-        write(lfndbg,'(a,1x,a,i5,a)') date(1:8),time(1:8), &
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,i5,a)') today(1:8),now(1:8), &
             me,' Returned from gronor_calculate '
         flush(lfndbg)
       endif
@@ -554,8 +549,8 @@ contains
       endif
       write(lfnmpi,'("send result buffer=",17(1x,e16.8))') (buffer(i),i=1,17)
       if(idbg.gt.10) then
-        call swatch(date,time)
-        write(lfndbg,'(a,1x,a,i5,a,7i7)') date(1:8),time(1:8), &
+        call swatch(today,now)
+        write(lfndbg,'(a,1x,a,i5,a,7i7)') today(1:8),now(1:8), &
             me,' sent results  ',mstr,(ibuf(i),i=1,4)
         flush(lfndbg)
       endif

--- a/src/utils/tps_utils.F90
+++ b/src/utils/tps_utils.F90
@@ -557,118 +557,27 @@ subroutine swatch(today,now)
 
   implicit none
 
-#if defined(LINUX) && !defined(IBM)
-  external :: linux_date,linux_time
-#endif
-  external :: tps_abort
+  character(len=10) :: today,now
+  character(len=8)  :: dstring,tstring
+  character(len=5)  :: zone
+  integer           :: values(8)
 
-  character*10 today,now
+  call date_and_time(dstring,tstring,zone,values)
 
-  !#if defined(LINUX)
-  !      character*26 string
-  !#endif
-#if defined(IBM)
-  character*26 dstring,tstring,tzone
-  integer :: dtvalue(8)
-#endif
-#if defined(KSR)
-  integer :: time
-  character*24 ctime,string
-#endif
-#if defined(SP1) || defined(CRAY_T3D) || defined(CRAY_T3E) || defined(SOLARIS)
-  character*26 string
-#endif
-#if defined(SGI)
-  character*9 string
-#endif
+  today(1:2) = dstring(3:4)
+  today(3:3) = '/'
+  today(4:5) = dstring(5:6)
+  today(6:6) = '/'
+  today(7:8) = dstring(7:8)
+  today(9:10) = '  '
 
-  today='00/00/00  '
-  now='00:00:00   '
+  now(1:2) = tstring(1:2)
+  now(3:3) = ':'
+  now(4:5) = tstring(3:4)
+  now(6:6) = ':'
+  now(7:8) = tstring(5:6)
+  now(9:10) = '  '
 
-#if defined(IBM)
-  !     call fdate(string)
-  call date_and_time(dstring,tstring,tzone,dtvalue)
-  today(1:2)=dstring(5:6)
-  today(4:5)=dstring(7:8)
-  today(7:8)=dstring(3:4)
-  !      if(string(4:6).eq.'Jan') today(1:2)='01'
-  !      if(string(4:6).eq.'Feb') today(1:2)='02'
-  !      if(string(4:6).eq.'Mar') today(1:2)='03'
-  !      if(string(4:6).eq.'Apr') today(1:2)='04'
-  !      if(string(4:6).eq.'May') today(1:2)='05'
-  !      if(string(4:6).eq.'Jun') today(1:2)='06'
-  !      if(string(4:6).eq.'Jul') today(1:2)='07'
-  !      if(string(4:6).eq.'Aug') today(1:2)='08'
-  !      if(string(4:6).eq.'Sep') today(1:2)='09'
-  !      if(string(4:6).eq.'Oct') today(1:2)='10'
-  !      if(string(4:6).eq.'Nov') today(1:2)='11'
-  !      if(string(4:6).eq.'Dec') today(1:2)='12'
-  !      today(7:8)=string(8:9)
-  !      today(4:5)=string(1:2)
-  now(1:2)=tstring(1:2)
-  now(4:5)=tstring(3:4)
-  now(7:8)=tstring(5:6)
-#endif
-#if defined(KSR)
-  string=ctime(time())
-  if(string(5:7).eq.'Jan') today(1:2)='01'
-  if(string(5:7).eq.'Feb') today(1:2)='02'
-  if(string(5:7).eq.'Mar') today(1:2)='03'
-  if(string(5:7).eq.'Apr') today(1:2)='04'
-  if(string(5:7).eq.'May') today(1:2)='05'
-  if(string(5:7).eq.'Jun') today(1:2)='06'
-  if(string(5:7).eq.'Jul') today(1:2)='07'
-  if(string(5:7).eq.'Aug') today(1:2)='08'
-  if(string(5:7).eq.'Sep') today(1:2)='09'
-  if(string(5:7).eq.'Oct') today(1:2)='10'
-  if(string(5:7).eq.'Nov') today(1:2)='11'
-  if(string(5:7).eq.'Dec') today(1:2)='12'
-  today(7:8)=string(23:24)
-  today(4:5)=string(9:10)
-  now=string(11:20)
-#endif
-#if defined(CRAY_T3D) || defined(SP1) || defined(CRAY_T3E) || defined(SOLARIS)
-  call date(string)
-  if(string(5:7).eq.'Jan') today(1:2)='01'
-  if(string(5:7).eq.'Feb') today(1:2)='02'
-  if(string(5:7).eq.'Mar') today(1:2)='03'
-  if(string(5:7).eq.'Apr') today(1:2)='04'
-  if(string(5:7).eq.'May') today(1:2)='05'
-  if(string(5:7).eq.'Jun') today(1:2)='06'
-  if(string(5:7).eq.'Jul') today(1:2)='07'
-  if(string(5:7).eq.'Aug') today(1:2)='08'
-  if(string(5:7).eq.'Sep') today(1:2)='09'
-  if(string(5:7).eq.'Oct') today(1:2)='10'
-  if(string(5:7).eq.'Nov') today(1:2)='11'
-  if(string(5:7).eq.'Dec') today(1:2)='12'
-  today(7:8)=string(23:24)
-  today(4:5)=string(9:10)
-  now=string(11:20)
-#endif
-#if defined(LINUX) && !defined(IBM)
-  call linux_date(today)
-  call linux_time(now)
-#endif
-#if defined(SGI)
-  call date(string)
-  if(string(4:6).eq.'Jan') today(1:2)='01'
-  if(string(4:6).eq.'Feb') today(1:2)='02'
-  if(string(4:6).eq.'Mar') today(1:2)='03'
-  if(string(4:6).eq.'Apr') today(1:2)='04'
-  if(string(4:6).eq.'May') today(1:2)='05'
-  if(string(4:6).eq.'Jun') today(1:2)='06'
-  if(string(4:6).eq.'Jul') today(1:2)='07'
-  if(string(4:6).eq.'Aug') today(1:2)='08'
-  if(string(4:6).eq.'Sep') today(1:2)='09'
-  if(string(4:6).eq.'Oct') today(1:2)='10'
-  if(string(4:6).eq.'Nov') today(1:2)='11'
-  if(string(4:6).eq.'Dec') today(1:2)='12'
-  today(7:8)=string(8:9)
-  today(4:5)=string(1:2)
-  call time(now(1:8))
-  now(9:10)='  '
-#endif
-  if(today(4:4).eq.' ') today(4:4)='0'
   return
 end subroutine swatch
 


### PR DESCRIPTION
## Summary
- Replace the multi-platform `swatch` implementation with one based on the intrinsic `date_and_time` to populate `today`/`now`
- Emit detailed array dimension and sample-value diagnostics from `gronor_moover` when `idbg>10`
- Add matching debug logging to `gronor_cofac1` and rename timing variables to `today`/`now`

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `ctest --test-dir build` *(fails: No tests were found)*
- `apt-get update` *(fails: repository InRelease files are not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689243ecd3d8832a838aa82f9ded5cfd