### PR TITLE
Use task-local vector size

### DIFF
--- a/src/gnome/gronor_cofac1.F90
+++ b/src/gnome/gronor_cofac1.F90
@@ -28,12 +28,13 @@
       use omp_lib
       implicit none
       contains
-      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
+      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,nveca_task)
 
       implicit none
 
       real (kind=8), intent(inout) :: a(:,:),u(:,:),w(:,:),wt(:,:),ev(:),ta(:,:)
       real (kind=8), intent(inout) :: diag(:),sdiag(:),cdiag(:),csdiag(:)
+      integer, intent(in) :: nveca_task
 
       external :: timer_start,timer_stop
       external :: gronor_abort
@@ -65,7 +66,7 @@
         write(lfndbg,'(a,1i10)') ' cdiag: ', size(cdiag)
         write(lfndbg,'(a,1i10)') ' csdiag:', size(csdiag)
         write(lfndbg,'(a,5i10)') ' scalars nelecs mbasel ntcla ntclb nveca:', &
-             nelecs, mbasel, ntcla, ntclb, nveca
+             nelecs, mbasel, ntcla, ntclb, nveca_task
         write(lfndbg,'(a,1x,es12.4)') ' a(1,1)=', a(1,1)
         write(lfndbg,'(a,1x,es12.4)') ' u(1,1)=', u(1,1)
         write(lfndbg,'(a,1x,es12.4)') ' w(1,1)=', w(1,1)

--- a/src/gnome/gronor_cororb.F90
+++ b/src/gnome/gronor_cororb.F90
@@ -24,9 +24,10 @@ module gronor_cororb_mod
   use gnome_data
   implicit none
 contains
-subroutine gronor_cororb(u,w,va,vb,ev)
+subroutine gronor_cororb(u,w,va,vb,ev,nveca_task)
   implicit none
   real (kind=8), intent(inout) :: u(:,:),w(:,:),va(:,:),vb(:,:),ev(:)
+  integer, intent(in) :: nveca_task
   integer :: i,j,k
 
   do i=1,nelecs
@@ -35,7 +36,7 @@ subroutine gronor_cororb(u,w,va,vb,ev)
         veca(j)=0.0d0
         vecb(j)=0.0d0
       enddo
-      do j=1,nveca
+      do j=1,nveca_task
         do k=1,mbasel
           veca(k)=veca(k)+u(j,i)*va(j,k)
           vecb(k)=vecb(k)+w(j,i)*vb(j,k)

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -55,6 +55,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
 
   integer :: lfndbg,ihc,nhc
   integer :: idet=0,k=0,iv=0,ib=0,ntvc=0,ivc=0,ibas=0
+  integer :: nveca_task
 
   logical (kind=4) :: flag=.false.
   integer (kind=4) :: ierr=0,status(MPI_STATUS_SIZE)=0
@@ -120,9 +121,9 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   ntopa=ntop(1)
   ntopb=ntop(2)
 
-  nveca=ntcla+ntopa
+  nveca_task=ntcla+ntopa
   nvecb=ntclb+ntopb
-  ntesta=nveca+ntcla
+  ntesta=nveca_task+ntcla
   ntestb=nvecb+ntclb
 
   if(ntesta.ne.ntestb) call gronor_abort(305,"Number of electrons is inconsistent")
@@ -159,14 +160,14 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
     write(lfndbg,'(a,i10)')  " ihc:   ", ihc
     write(lfndbg,'(a,i10)')  " nhc:   ", nhc
-    write(lfndbg,'(a,i10)')  " nveca: ", nveca
+    write(lfndbg,'(a,i10)')  " nveca: ", nveca_task
     write(lfndbg,'(a,i10)')  " nvecb: ", nvecb
     write(lfndbg,'(a,i10)')  " nelecs:", nelecs
     write(lfndbg,'(a,i10)')  " mbasel:", mbasel
     flush(lfndbg)
   endif
 
-  if(nveca.ne.ntcl(1)+ntop(1)) call gronor_abort(306,"Incompatible nveca")
+  if(nveca_task.ne.ntcl(1)+ntop(1)) call gronor_abort(306,"Incompatible nveca")
   if(nvecb.ne.ntcl(2)+ntop(2)) call gronor_abort(307,"Incompatible nvecb")
 
   if(idbg.gt.40) then
@@ -186,7 +187,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   endif
 
   do ib=1,nbas
-    do iv=1,nveca
+    do iv=1,nveca_task
       va(iv,ib)=vec(iv,ib,1)
     enddo
   enddo
@@ -209,13 +210,13 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     !  Calculations of the overlap matrices
 
     call timer_start(14)
-    call gronor_moover(lfndbg,va,vb,tb,ta,a)
+    call gronor_moover(lfndbg,va,vb,tb,ta,a,nveca_task)
     call timer_stop(14)
 
     !  Calculation of the cofactor matrices and arrays corresponding to the total overlap
 
     call timer_start(15)
-    call gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
+    call gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,nveca_task)
     call timer_stop(15)
 
     if(idbg.ge.20) then
@@ -233,7 +234,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
 
       if(corres) then
         call timer_start(16)
-        call gronor_cororb(u,w,va,vb,ev)
+        call gronor_cororb(u,w,va,vb,ev,nveca_task)
         call timer_stop(16)
       endif
 
@@ -263,7 +264,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
       !     (x-matrix to f-matrix in terms of the basis set of the 2-el.integr
 
       call timer_start(20)
-      call gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
+      call gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag,nveca_task)
       call timer_stop(20)
 
       !     Calculation of the one electron Hamiltonian matrix elements

--- a/src/gnome/gronor_main.F90
+++ b/src/gnome/gronor_main.F90
@@ -2000,18 +2000,17 @@ subroutine gronor_main()
       enddo
 
       nelecs=0
-      nveca=0
+      nveca_max=0
       n=0
       do ibase=1,nbase
-        nveca=max(nveca,inactb(ibase)+nactb(ibase))
+        nveca_max=max(nveca_max,inactb(ibase)+nactb(ibase))
         n=2*inactb(ibase)
         do iact=1,nactb(ibase)
           n=n+iabs(int(iocc(1,ibase,iact),kind=kind(n)))
         enddo
         nelecs=max(nelecs,n)
       enddo
-
-      nvecb=nveca
+      nvecb=nveca_max
       nstdim=max(1,nelecs*nelecs,nbas*(nbas+1)/2)
       mbasel=max(nelecs,nbas)
 

--- a/src/gnome/gronor_memory_usage.F90
+++ b/src/gnome/gronor_memory_usage.F90
@@ -47,7 +47,7 @@ subroutine gronor_memory_usage()
   if(me.eq.0) then
     membuf(1)=mbasel
     membuf(2)=mvec
-    membuf(3)=nveca
+    membuf(3)=nveca_max
     membuf(4)=nvecb
     membuf(5)=nstdim
     membuf(6)=nelecs
@@ -68,7 +68,7 @@ subroutine gronor_memory_usage()
     call MPI_Recv(membuf,ncount,MPI_INTEGER8,MPI_ANY_SOURCE,mpitag,MPI_COMM_WORLD,istat,ierr)
     mbasel=membuf(1)
     mvec=membuf(2)
-    nveca=membuf(3)
+    nveca_max=membuf(3)
     nvecb=membuf(4)
     nstdim=membuf(5)
     nelecs=membuf(6)
@@ -102,7 +102,7 @@ subroutine gronor_memory_usage()
     gb=real(4*ni)/real(1073741824)
     write(lfnout,601) "ME List",gb
 
-    ni=mbasel*(2+4*mvec+nveca+2*nvecb+7*max(mbasel,nveca)+mbasel)
+    ni=mbasel*(2+4*mvec+nveca_max+2*nvecb+7*max(mbasel,nveca_max)+mbasel)
     ni=ni+nstdim+nelecs*(1+3*nelecs+6*mbasel)
     if(nbatch.lt.0) then
       ni=ni+ntask*(1+4*nbas+6*nbas*nbas)+16

--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -204,7 +204,7 @@ module gnome_data
 
   integer :: nnucl,nbas,numint,numfiles
 
-  integer :: nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb
+  integer :: nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb,nveca_max
 
   integer :: ntcl(2), ntop(2), nclose(2), nopen(2), nelec(2)
   integer :: nact(2), ninact(2)
@@ -257,7 +257,7 @@ module gnome_data
 
   integer :: ising
 !$omp threadprivate(ntesta,ntestb,ijend)
-!$omp threadprivate(nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb,n1bas,nstdim,mbasel,nelecs)
+!$omp threadprivate(nalfa,nveca,nvecb,ntcla,ntclb,ntopa,ntopb,nveca_max,n1bas,nstdim,mbasel,nelecs)
 !$omp threadprivate(e1,e2,e2c,etot,etotb,deta,fac,fctr,mpoles,e1tot,e2tot,sstot,hh,ss,ttest,ising)
 !$omp threadprivate(ntcl,ntop,nclose,nopen,nelec,nact,ninact,iocopen)
 !$omp threadprivate(ioccup,vec,vtemp,ioccn,iocopen)

--- a/src/gnome/gronor_moover.F90
+++ b/src/gnome/gronor_moover.F90
@@ -28,11 +28,12 @@ module gronor_moover_mod
   use omp_lib
   implicit none
 contains
-subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
+subroutine gronor_moover(lfndbg,va,vb,tb,ta,a,nveca_task)
 
   implicit none
 
   real (kind=8), intent(inout) :: va(:,:),vb(:,:),tb(:,:),ta(:,:),a(:,:)
+  integer, intent(in) :: nveca_task
 
   external :: gronor_abort
 
@@ -76,7 +77,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
     write(lfndbg,'(a,2i10)') ' ta:    ', size(ta,1), size(ta,2)
     write(lfndbg,'(a,2i10)') ' a:     ', size(a,1), size(a,2)
     write(lfndbg,'(a,5i10)') ' nbas nelecs nveca nvecb nalfa:', &
-         nbas, nelecs, nveca, nvecb, nalfa
+         nbas, nelecs, nveca_task, nvecb, nalfa
     write(lfndbg,'(a,2i10)') ' ntcla ntclb:', ntcla, ntclb
     write(lfndbg,'(a,1x,es12.4)') ' va(1,1)=', va(1,1)
     write(lfndbg,'(a,1x,es12.4)') ' vb(1,1)=', vb(1,1)
@@ -179,14 +180,14 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 
   ! Calculation for beta spin in open-shell-m.o.'s
 
-  if(nveca.ne.nalfa) then
+  if(nveca_task.ne.nalfa) then
 
     if(ntclb.gt.0) then
 
 !$acc kernels present(va,ta,tb)
       do k=1,ntclb
         kk=k+nalfa
-        do i=m1,nveca
+        do i=m1,nveca_task
           sum=0.0d0
           do l=1,nbas
             sum=sum+va(i,l)*tb(l,k)
@@ -203,7 +204,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 !$acc kernels present(va,ta,tb)
       do k=nalfa+1,nvecb
         kk=k+ntclb
-        do i=m1,nveca
+        do i=m1,nveca_task
           sum=0.0d0
           do l=1,nbas
             sum=sum+va(i,l)*tb(l,k)

--- a/src/gnome/gronor_tramat.F90
+++ b/src/gnome/gronor_tramat.F90
@@ -20,7 +20,7 @@
 !!
 
 
-subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
+subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag,nveca_task)
 
   !      This routine mutiplies the input-matrix (a)
   !       (which is positioned in a workmatrix (aa))
@@ -38,6 +38,7 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
   use gnome_data
   implicit none
   real (kind=8), intent(inout) :: va(:,:),vb(:,:),ta(:,:),taa(:,:),w1(:),w2(:,:),diag(:),sdiag(:)
+  integer, intent(in) :: nveca_task
   integer :: i,j,k,kk,m1
   real (kind=8) :: sum
 
@@ -77,11 +78,11 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
           enddo
         endif
       endif
-      if(nalfa .ne. nveca) then
+      if(nalfa .ne. nveca_task) then
 #ifdef ACC
 !$acc loop reduction(+:sum)
 #endif
-        do k=m1,nveca
+        do k=m1,nveca_task
           kk=k+ntcla
           sum=sum+diag(kk)*va(k,j)
         enddo
@@ -120,11 +121,11 @@ subroutine gronor_tramat(va,vb,ta,taa,w1,w2,diag,sdiag)
           enddo
         endif
       endif
-      if(nalfa .ne. nveca) then
+      if(nalfa .ne. nveca_task) then
 #ifdef ACC
 !$acc loop seq reduction(+:sum)
 #endif
-        do k=m1,nveca
+        do k=m1,nveca_task
           kk=k+ntcla
           sum=sum+va(k,i)*taa(kk,j)
         enddo

--- a/src/gnome/gronor_tramat2.F90
+++ b/src/gnome/gronor_tramat2.F90
@@ -25,7 +25,7 @@ module gronor_tramat2_mod
   use gnome_data
   implicit none
 contains
-subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
+subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag,nveca_task)
 
   !      Transformation of the  m.o.'s
   !      the new  m.o.'s are adapted to the basis set of the two electon
@@ -34,6 +34,7 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
   implicit none
   integer :: lfndbg
   real (kind=8), intent(inout) :: va(:,:),vb(:,:),ta(:,:),aaa(:,:),w1(:),w2(:,:),diag(:),bdiag(:),bsdiag(:),cdiag(:),csdiag(:),sdiag(:)
+  integer, intent(in) :: nveca_task
 
   integer :: i,j,k,kk,m1
   real (kind=8) :: sum
@@ -80,13 +81,13 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
       enddo
     endif
 
-    if(nalfa.ne.nveca) then
+    if(nalfa.ne.nveca_task) then
       m1=nalfa+1
 !$acc loop private(sum)
       do j=1,nbas
         sum=0.0d0
 !$acc loop reduction(+:sum)
-        do k=m1,nveca
+        do k=m1,nveca_task
           kk=k+ntcla
           sum=sum+cdiag(kk)*va(k,j)
         enddo
@@ -229,9 +230,9 @@ subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdi
             sum=sum+ta(kk,j)*va(k,i)
           enddo
         endif
-        if(nalfa.ne.nveca) then
+        if(nalfa.ne.nveca_task) then
 !$acc loop seq reduction(+:sum) private(kk)
-          do k=m1,nveca
+          do k=m1,nveca_task
             kk=k+ntcla
             sum=sum+ta(kk,j)*va(k,i)
           enddo

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -87,18 +87,16 @@ subroutine gronor_worker()
   enddo
 
   nelecs=0
-  nveca=0
+  nveca_max=0
   n=0
   do ibase=1,nbase
-    nveca=max(nveca,inactb(ibase)+nactb(ibase))
+    nveca_max=max(nveca_max,inactb(ibase)+nactb(ibase))
     n=2*inactb(ibase)
     do iact=1,nactb(ibase)
       n=n+iabs(int(iocc(1,ibase,iact),kind=kind(n)))
     enddo
     nelecs=max(nelecs,n)
   enddo
-
-  nvecb=nveca
   nstdim=max(1,nelecs*nelecs,nbas*(nbas+1)/2)
   mbasel=max(nelecs,nbas)
 
@@ -121,19 +119,19 @@ subroutine gronor_worker()
 !$omp& ibase,jbase,idet,jdet,nidet,njdet,i,j,k,l2,n,iact,ibuf,status,tbuf,lfnmpi,mpifile,ireq,ierr,ncount,mpitag,mpidest, &
 !$omp& mpi_err_len,ierr2,mpi_err_str,today,now,flag) &
 !$omp& copyin(oterm,otreq,odupl,itreq,irbuf,icur,jcur,lsvcpu,levcpu,lsvtrns, &
-!$omp&        ndeti,ndetj,nacti,nactj,inacti,inactj,nelecs,nveca,nvecb,nstdim,mbasel, &
+!$omp&        ndeti,ndetj,nacti,nactj,inacti,inactj,nelecs,nveca_max,nstdim,mbasel, &
 !$omp&        ntcl,ntop,nclose,nopen,nelec,nact,ninact)
 
   thread_id = omp_get_thread_num()
 
   allocate(a(nelecs,nelecs))
-  allocate(ta(mbasel,max(mbasel,nveca)))
-  allocate(tb(mbasel,nvecb))
-  allocate(va(nveca,mbasel))
-  allocate(vb(nvecb,mbasel))
+  allocate(ta(mbasel,max(mbasel,nveca_max)))
+  allocate(tb(mbasel,nveca_max))
+  allocate(va(nveca_max,mbasel))
+  allocate(vb(nveca_max,mbasel))
   allocate(w1(max(nelecs,nbas,mbasel)))
   allocate(w2(max(nelecs,nbas,mbasel),max(nelecs,nbas,mbasel)))
-  allocate(taa(mbasel,max(mbasel,nveca)))
+  allocate(taa(mbasel,max(mbasel,nveca_max)))
 
   allocate(u(nelecs,nelecs))
   allocate(w(nelecs,nelecs))
@@ -145,10 +143,10 @@ subroutine gronor_worker()
   allocate(bsdiag(max(nelecs,nbas,mbasel)))
   allocate(csdiag(max(nelecs,nbas,mbasel)))
   allocate(sdiag(max(nelecs,nbas,mbasel)))
-  allocate(aaa(mbasel,max(mbasel,nveca)))
-  allocate(tt(mbasel,max(mbasel,nveca)))
-  allocate(aat(mbasel,max(mbasel,nveca)))
-  allocate(sm(mbasel,max(mbasel,nveca)))
+  allocate(aaa(mbasel,max(mbasel,nveca_max)))
+  allocate(tt(mbasel,max(mbasel,nveca_max)))
+  allocate(aat(mbasel,max(mbasel,nveca_max)))
+  allocate(sm(mbasel,max(mbasel,nveca_max)))
   allocate(ioccup(mnact,2))
   allocate(iocopen(mnact,2))  ! thread-local open-shell occupation
   allocate(vec(mvec,mbasel,2))
@@ -204,8 +202,7 @@ subroutine gronor_worker()
     write(lfndbg,'(a,i10)')  " cdiag: ", size(cdiag)
     write(lfndbg,'(a,2i10)') " taa:   ", size(taa,1), size(taa,2)
     write(lfndbg,'(a,i10)')  " nelecs:", nelecs
-    write(lfndbg,'(a,i10)')  " nveca: ", nveca
-    write(lfndbg,'(a,i10)')  " nvecb: ", nvecb
+    write(lfndbg,'(a,i10)')  " nveca_max: ", nveca_max
     write(lfndbg,'(a,i10)')  " mbasel:", mbasel
     write(lfndbg,'(a,i10)')  " nstdim:", nstdim
     flush(lfndbg)


### PR DESCRIPTION
## Summary
- track maximum determinant size via thread-private `nveca_max`
- base worker allocations on `nveca_max`
- compute GNOME task dimensions locally and forward to helper routines

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6c9dc20832a829f003b99487891