### PR TITLE
Refactor solver workspaces into per-thread arrays

### DIFF
--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -41,7 +41,7 @@ module gronor_calculate_mod
   use gronor_gnome_mod, only: gronor_gnome
   implicit none
 contains
-subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
   implicit none
 
@@ -49,6 +49,8 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
   real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
   real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
+  real (kind=8), intent(inout) :: workspace_d(:)
+  integer (kind=8), intent(inout) :: workspace_i(:)
 
   external :: swatch,timer_start,timer_stop
   external :: gronor_abort
@@ -377,7 +379,7 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
 
       call timer_start(6)
 
-      call gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+      call gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
       call timer_stop(6)
 

--- a/src/gnome/gronor_cofac1.F90
+++ b/src/gnome/gronor_cofac1.F90
@@ -30,12 +30,14 @@
       use omp_lib
       implicit none
       contains
-      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
+      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,workspace_d,workspace_i)
 
       implicit none
 
       real (kind=8), intent(inout) :: a(:,:),u(:,:),w(:,:),wt(:,:),ev(:),ta(:,:)
       real (kind=8), intent(inout) :: diag(:),sdiag(:),cdiag(:),csdiag(:)
+      real (kind=8), intent(inout) :: workspace_d(:)
+      integer (kind=8), intent(inout) :: workspace_i(:)
 
       external :: timer_start,timer_stop
       external :: gronor_abort
@@ -136,7 +138,7 @@
       endif
 
       call timer_start(41)
-      call gronor_svd(a,ev,u,w,sdiag,wt)
+      call gronor_svd(a,ev,u,w,sdiag,wt,workspace_d,workspace_i)
       call timer_stop(41)
 
   !  Calculation of det(uw) by determination of the number of eigenvalues -2 of a=uw+transpose(uw)
@@ -215,7 +217,7 @@
 
       call timer_start(43)
       
-      call gronor_evd(a,diag,sdiag)
+      call gronor_evd(a,diag,sdiag,workspace_d,workspace_i)
 
       call timer_stop(43)
       

--- a/src/gnome/gronor_evd.F90
+++ b/src/gnome/gronor_evd.F90
@@ -23,7 +23,7 @@ module gronor_evd_mod
   implicit none
 contains
 
-subroutine gronor_evd(a,diag,sdiag)
+subroutine gronor_evd(a,diag,sdiag,workspace_d,workspace_i)
 
   !> Routine that provides all possible calls to Eigensolver library routines
   !! including routines executed on the CPU or on GPU accelerators
@@ -71,6 +71,8 @@ subroutine gronor_evd(a,diag,sdiag)
   implicit none
 
   real (kind=8), intent(inout) :: a(:,:),diag(:),sdiag(:)
+  real (kind=8), intent(inout) :: workspace_d(:)
+  integer (kind=8), intent(inout) :: workspace_i(:)
 
   external :: tred2,tql2
 #ifdef MKL

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -38,7 +38,7 @@ module gronor_gnome_mod
   use gronor_dipole_mod,    only: gronor_dipole
   implicit none
 contains
-subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
   implicit none
 
@@ -46,6 +46,8 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
   real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
   real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
+  real (kind=8), intent(inout) :: workspace_d(:)
+  integer (kind=8), intent(inout) :: workspace_i(:)
 
   external :: timer_start,timer_stop
   external :: gronor_abort
@@ -215,7 +217,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     !  Calculation of the cofactor matrices and arrays corresponding to the total overlap
 
     call timer_start(15)
-    call gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag)
+    call gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,workspace_d,workspace_i)
     call timer_stop(15)
 
     if(idbg.ge.20) then

--- a/src/gnome/gronor_main.F90
+++ b/src/gnome/gronor_main.F90
@@ -2146,7 +2146,7 @@ subroutine gronor_main()
         trim(architecture),trim(lmodcomp),trim(lmodcompv),trim(lmodmpi), &
         trim(lmodmpiv),trim(usedcmake)
     write(lfnlog,812) trim(user),trim(string),trim(command),tau_MO,tau_CI,tau_CI_off, &
-        len_work_dbl,len_work2_dbl,len_work_int,numtasks
+        len_work_dbl,len_work_int,numtasks
     if(numacc.gt.0) then
       write(lfnlog,813) trim(asvd),trim(aevd),trim(nsvd),trim(nevd)
     else
@@ -2154,7 +2154,7 @@ subroutine gronor_main()
     endif
 801 format(a8,1x,a8,f9.3,2f12.3,4i7,4i3,5i2,4i5,3i3,2x,a1)
 802 format(a17,t19,a,1x,a,a,a,1x,a,1x,a,'/',a,1x,a,'/',a," cmake/",a)
-812 format(2x,a,t12,a,t35,a,t45,1pe9.2,2e9.2,4i10)
+812 format(2x,a,t12,a,t35,a,t45,1pe9.2,2e9.2,3i10)
 813 format(2x,"GPU solvers: ",a," and ",a,5x,"CPU solvers: ",a," and ",a)
 814 format(2x,"CPU solvers: ",a," and ",a)
     write(lfnlog,803) (hbase(i,i),i=1,nbase)

--- a/src/gnome/gronor_mods.F90
+++ b/src/gnome/gronor_mods.F90
@@ -262,9 +262,8 @@ module gnome_data
 !$omp threadprivate(ntcl,ntop,nclose,nopen,nelec,nact,ninact,iocopen)
 !$omp threadprivate(ioccup,vec,vtemp,ioccn,iocopen)
 
-!  real (kind=8), allocatable :: work(:)
-  integer (kind=8) :: len_work_dbl,len_work2_dbl,len_work_int,info
-!$omp threadprivate(len_work_dbl,len_work2_dbl,len_work_int,info)
+  integer (kind=8) :: len_work_dbl,len_work_int,info
+!$omp threadprivate(len_work_dbl,len_work_int,info)
 
   real (kind=8) :: buffer(17)
 !$omp threadprivate(buffer,e2buff,e2summ)
@@ -375,13 +374,6 @@ module gnome_solvers
   integer (kind=4) :: mdim,ndim,ndim4,lwork4,liwork4
 !$omp threadprivate(ndimm,mdimm,lwork,liwork,ndim8,lwork8,liwork8,mdim,ndim,ndim4,lwork4,liwork4)
 
-  real(kind=8), allocatable :: work(:)
-  integer(kind=8), allocatable :: iwork(:)
-  real (kind=8),allocatable :: workspace_d(:)
-  real (kind=8),allocatable :: workspace2_d(:)
-  integer (kind=8), allocatable :: workspace_i(:)
-  integer (kind=4), allocatable :: workspace_i4(:)
-!$omp threadprivate(workspace_d,workspace2_d,workspace_i,workspace_i4)
 !  character*1 :: jobz,uplo
   integer (kind=4) :: jobz,uplo
 end module gnome_solvers

--- a/src/gnome/gronor_solver_init.F90
+++ b/src/gnome/gronor_solver_init.F90
@@ -54,16 +54,14 @@ subroutine gronor_solver_init(ntemp,a,u,w,ev)
 
   integer (kind=8) :: lworki,lwork1m,lwork2m
   integer (kind=8) :: min_work_dbl,min_work_int
-  integer (kind=4) :: lwork1,lwork2
 
-  real(kind=8) :: worksize(2),worksize2(2)
+  real(kind=8) :: worksize(2)
   integer (kind=4) :: iworksize(2)
 
   nelecs=ntemp
 
   len_work_int=0
   len_work_dbl=0
-  len_work2_dbl=0
 
 ! Cusolver initialization for the svd
 
@@ -140,8 +138,6 @@ subroutine gronor_solver_init(ntemp,a,u,w,ev)
 
     len_work_dbl=max(1,len_work_dbl)
     len_work_int=max(1,len_work_int)
-    len_work2_dbl=max(1,len_work2_dbl)
-
     min_work_dbl=max(1_8,3*nelecs)
     min_work_int=max(1_8,nelecs)
     if(len_work_dbl<min_work_dbl .or. len_work_int<min_work_int) then
@@ -153,11 +149,6 @@ subroutine gronor_solver_init(ntemp,a,u,w,ev)
           ' int=',len_work_int,' flags',lsvcpu,levcpu,lsvtrns
       flush(lfndbg)
     endif
-
-    allocate(workspace_d(len_work_dbl))
-    allocate(workspace2_d(len_work2_dbl))
-    allocate(workspace_i(len_work_int))
-    allocate(workspace_i4(len_work_int))
 
     return
 end subroutine gronor_solver_init

--- a/src/gnome/gronor_svd.F90
+++ b/src/gnome/gronor_svd.F90
@@ -22,7 +22,7 @@ module gronor_svd_mod
   implicit none
 contains
 
-subroutine gronor_svd(a,ev,u,w,sdiag,wt)
+subroutine gronor_svd(a,ev,u,w,sdiag,wt,workspace_d,workspace_i)
 
   !> Routine that provides all possible calls to Singular Value Decomposition library routines
   !! including routines executed on the CPU or on GPU accelerators 
@@ -73,6 +73,8 @@ subroutine gronor_svd(a,ev,u,w,sdiag,wt)
   implicit none
 
   real (kind=8), intent(inout) :: a(:,:),ev(:),u(:,:),w(:,:),sdiag(:),wt(:,:)
+  real (kind=8), intent(inout) :: workspace_d(:)
+  integer (kind=8), intent(inout) :: workspace_i(:)
 
   external :: svd,dgesvd
 
@@ -92,6 +94,14 @@ subroutine gronor_svd(a,ev,u,w,sdiag,wt)
   thread_id = 0
 #endif
   if(idbg.gt.10 .and. thread_id==0) then
+    if(iamacc.eq.1 .and. .not.lsvcpu) then
+#ifdef ACC
+      !$acc update host(a,u,w,wt,ev,sdiag)
+#endif
+#ifdef OMPTGT
+      !$omp target update from(a,u,w,wt,ev,sdiag)
+#endif
+    endif
     call swatch(today,now)
     write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8), &
          ' Array dimensions check in gronor_svd:'
@@ -140,6 +150,9 @@ subroutine gronor_svd(a,ev,u,w,sdiag,wt)
   if(iamacc.eq.1.and.lsvcpu) then
 #ifdef ACC
 !$acc update host (a)
+#endif
+#ifdef OMPTGT
+  !$omp target update from(a)
 #endif
   endif
 
@@ -195,6 +208,9 @@ subroutine gronor_svd(a,ev,u,w,sdiag,wt)
   if(iamacc.eq.1.and.lsvcpu) then
 #ifdef ACC
 !$acc update device (ev,u,w)
+#endif
+#ifdef OMPTGT
+  !$omp target update to(ev,u,w)
 #endif
   endif
 

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -56,6 +56,8 @@ subroutine gronor_worker()
   real (kind=8), allocatable :: csdiag(:),cdiag(:)
   real (kind=8), allocatable :: w1(:),w2(:,:)
   real (kind=8), allocatable :: taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
+  real (kind=8), allocatable :: workspace_d(:)
+  integer (kind=8), allocatable :: workspace_i(:)
 
   logical (kind=4) :: flag
 
@@ -117,7 +119,7 @@ subroutine gronor_worker()
 #ifdef _OPENMP
   call omp_set_num_threads(num_threads)
 
-!$omp parallel private(thread_id,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag, &
+!$omp parallel private(thread_id,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i, &
 !$omp& ibase,jbase,idet,jdet,nidet,njdet,i,j,k,l2,n,iact,ibuf,status,tbuf,lfnmpi,mpifile,ireq,ierr,ncount,mpitag,mpidest, &
 !$omp& mpi_err_len,ierr2,mpi_err_str,today,now,flag) &
 !$omp& copyin(oterm,otreq,odupl,itreq,irbuf,icur,jcur,lsvcpu,levcpu,lsvtrns, &
@@ -170,6 +172,9 @@ subroutine gronor_worker()
 
   call gronor_solver_init(nelecs, a, u, w, ev)
 
+  allocate(workspace_d(len_work_dbl))
+  allocate(workspace_i(len_work_int))
+
   if(idbg.gt.50 .and. thread_id==0) then
     call swatch(today,now)
     write(lfndbg,'(a,1x,a,a)') today(1:8),now(1:8)," Solver initialization completed"
@@ -219,7 +224,7 @@ subroutine gronor_worker()
   endif
 
 
-  call gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+  call gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
   call gronor_solver_finalize()
 
@@ -231,6 +236,8 @@ subroutine gronor_worker()
   deallocate(w1)
   deallocate(w2)
   deallocate(taa)
+  deallocate(workspace_d)
+  deallocate(workspace_i)
   deallocate(u)
   deallocate(w)
   deallocate(wt)
@@ -272,7 +279,7 @@ subroutine gronor_worker()
 
 contains
 
-  subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+  subroutine gronor_worker_process(va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
   use mpi
   use cidef
@@ -289,6 +296,8 @@ contains
   real (kind=8), intent(inout) :: u(:,:),w(:,:),wt(:,:),ev(:)
   real (kind=8), intent(inout) :: w1(:),w2(:,:),taa(:,:),sm(:,:),aaa(:,:),aat(:,:),tt(:,:)
   real (kind=8), intent(inout) :: sdiag(:),diag(:),bsdiag(:),bdiag(:),csdiag(:),cdiag(:)
+  real (kind=8), intent(inout) :: workspace_d(:)
+  integer (kind=8), intent(inout) :: workspace_i(:)
 
 !  external :: MPI_Recv,MPI_iRecv,MPI_iSend
 
@@ -517,7 +526,7 @@ contains
       endif
       call timer_start(47)
 
-      call gronor_calculate(ibase,jbase,idet,jdet,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag)
+      call gronor_calculate(ibase,jbase,idet,jdet,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
       call timer_stop(47)
 


### PR DESCRIPTION
## Summary
- Remove unused solver scratch arrays and secondary workspace length
- Pass only required double and 64-bit integer workspaces through solver call chain
- Allocate minimal workspaces per worker thread

## Testing
- `cmake -DMKL=ON ..` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893d08b4a88832a99f990c7702bd3bb