### PR TITLE
Ensure VA/VB updates are synced to GPU in GNOME

### DIFF
--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -198,6 +198,8 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
     enddo
   enddo
 
+!$acc update device(va(1:nveca,1:nbas), vb(1:nvecb,1:nbas))
+
   if(idbg.ge.10) then
     write(lfndbg,3612) iamacc
 3612 format(" GNOME with iamacc ",i5)
@@ -237,6 +239,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,
         call timer_start(16)
         call gronor_cororb(u,w,va,vb,ev)
         call timer_stop(16)
+!$acc update device(va(1:nveca,1:nbas), vb(1:nvecb,1:nbas))
       endif
 
       call timer_start(17)


### PR DESCRIPTION
## Summary
- Push VA and VB coefficient updates to the GPU after host-side initialization
- Sync VA/VB coefficients to the device after CPU-based gronor_cororb adjustments

## Testing
- `ctest` (fails: No test configuration file found)

------
https://chatgpt.com/codex/tasks/task_e_689452a7ff48832ab5527890fafa0898