### PR TITLE
Initialize thread-private energies before GNOME call

### DIFF
--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -379,6 +379,13 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
 
       call timer_start(6)
 
+      e1   = 0.0d0
+      e2   = 0.0d0
+      deta = 0.0d0
+      hh   = 0.0d0
+      etot = 0.0d0
+      ss   = 0.0d0
+
       call gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
       call timer_stop(6)

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -125,7 +125,9 @@ subroutine gronor_worker()
 !$omp& mpi_err_len,ierr2,mpi_err_str,today,now,flag,fildbg_thr) &
 !$omp& copyin(oterm,otreq,odupl,itreq,irbuf,icur,jcur,lsvcpu,levcpu,lsvtrns, &
 !$omp&        ndeti,ndetj,nacti,nactj,inacti,inactj,nelecs,nveca,nvecb,nstdim,mbasel, &
-!$omp&        ntcl,ntop,nclose,nopen,nelec,nact,ninact)
+!$omp&        ntcl,ntop,nclose,nopen,nelec,nact,ninact, &
+!$omp&        e1,e2,e2c,etot,etotb,deta,fac,fctr,mpoles, &
+!$omp&        e1tot,e2tot,sstot,hh,ss,ttest,ising)
 
   thread_id = omp_get_thread_num()
 


### PR DESCRIPTION
## Summary
- Reset local energy and overlap variables to zero before invoking `gronor_gnome`
- Ensure OpenMP workers copy in thread-private energy accumulators at parallel region entry

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get install -y gfortran` *(fails: Unable to locate package gfortran)*

------
https://chatgpt.com/codex/tasks/task_e_689496652e3c832a82dcd293b5a0ff07