### PR TITLE
Normalize debug file handling

### DIFF
--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -386,7 +386,7 @@ subroutine gronor_calculate(ib,jb,id1,id2,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,a
       etot = 0.0d0
       ss   = 0.0d0
 
-      call gronor_gnome(lfndbg,ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
+      call gronor_gnome(ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,sdiag,diag,bsdiag,bdiag,csdiag,cdiag,workspace_d,workspace_i)
 
       call timer_stop(6)
 

--- a/src/gnome/gronor_cofac1.F90
+++ b/src/gnome/gronor_cofac1.F90
@@ -28,9 +28,10 @@
       use gronor_svd_mod, only: gronor_svd
       use gronor_evd_mod, only: gronor_evd
       use omp_lib
+      use cidef
       implicit none
       contains
-      subroutine gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,workspace_d,workspace_i)
+      subroutine gronor_cofac1(a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,workspace_d,workspace_i)
 
       implicit none
 
@@ -42,7 +43,6 @@
       external :: timer_start,timer_stop
       external :: gronor_abort
 
-      integer :: lfndbg
       integer :: i,j,idetuw,k
       integer :: imax,jmax,iout,jout
       real (kind=8) :: coef

--- a/src/gnome/gronor_dipole.F90
+++ b/src/gnome/gronor_dipole.F90
@@ -23,11 +23,11 @@ module gronor_dipole_mod
   use cidist
   use gnome_parameters
   use gnome_data
+  use cidef
   implicit none
 contains
-subroutine gronor_dipole(lfndbg,ta,diag,sdiag)
+subroutine gronor_dipole(ta,diag,sdiag)
   implicit none
-  integer :: lfndbg
   real (kind=8), intent(inout) :: ta(:,:),diag(:),sdiag(:)
 
   integer :: i,j

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -102,7 +102,7 @@ subroutine gronor_gnome(ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,
     endif
 
     call timer_start(11)
-    call gronor_transvc(lfndbg, idet)
+    call gronor_transvc(idet)
     call timer_stop(11)
 
     call timer_start(12)
@@ -110,7 +110,7 @@ subroutine gronor_gnome(ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,
     call timer_stop(12)
 
     call timer_start(13)
-    call gronor_tranout(lfndbg,idet)
+    call gronor_tranout(idet)
     call timer_stop(13)
 
     if(idbg.ge.20) write(lfndbg,606) idet
@@ -224,13 +224,13 @@ subroutine gronor_gnome(ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,
     !  Calculations of the overlap matrices
 
     call timer_start(14)
-    call gronor_moover(lfndbg,va,vb,tb,ta,a)
+    call gronor_moover(va,vb,tb,ta,a)
     call timer_stop(14)
 
     !  Calculation of the cofactor matrices and arrays corresponding to the total overlap
 
     call timer_start(15)
-    call gronor_cofac1(lfndbg,a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,workspace_d,workspace_i)
+    call gronor_cofac1(a,u,w,wt,ev,ta,diag,sdiag,cdiag,csdiag,workspace_d,workspace_i)
     call timer_stop(15)
 
     if(idbg.ge.20) then
@@ -259,7 +259,7 @@ subroutine gronor_gnome(ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,
 
       if(idipole.ne.0) then
         call timer_start(18)
-        call gronor_dipole(lfndbg,ta,diag,sdiag)
+        call gronor_dipole(ta,diag,sdiag)
         call timer_stop(18)
       endif
 
@@ -279,13 +279,13 @@ subroutine gronor_gnome(ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,
       !     (x-matrix to f-matrix in terms of the basis set of the 2-el.integr
 
       call timer_start(20)
-      call gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
+      call gronor_tramat2(va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
       call timer_stop(20)
 
       !     Calculation of the one electron Hamiltonian matrix elements
 
       call timer_start(21)
-      if(icalc.le.1.and.ising.le.1) call gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
+      if(icalc.le.1.and.ising.le.1) call gronor_gnone(diag,bdiag,bsdiag,csdiag,ta,aaa)
       call timer_stop(21)
     endif
 
@@ -299,9 +299,9 @@ subroutine gronor_gnome(ihc,nhc,va,vb,tb,ta,a,u,w,wt,ev,w1,w2,taa,sm,aaa,aat,tt,
       ! else
       ! Thanks! but we do not use batch 
         if(idevel.eq.0.or.mgr.gt.1) then
-          if(ising.le.2) call gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
+          if(ising.le.2) call gronor_gntwo(aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
         else
-          if(ising.le.2) call gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
+          if(ising.le.2) call gronor_gntwo_canonical(aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
         endif
       ! endif
       !         call nvtxEndRange

--- a/src/gnome/gronor_gnone.F90
+++ b/src/gnome/gronor_gnone.F90
@@ -32,11 +32,11 @@ module gronor_gnone_mod
   use gnome_parameters
   use gnome_data
   use gnome_integrals
+  use cidef
   implicit none
 contains
-subroutine gronor_gnone(lfndbg,diag,bdiag,bsdiag,csdiag,ta,aaa)
+subroutine gronor_gnone(diag,bdiag,bsdiag,csdiag,ta,aaa)
   implicit none
-  integer :: lfndbg
   real (kind=8), intent(inout) :: diag(:),bdiag(:),bsdiag(:),csdiag(:),ta(:,:),aaa(:,:)
 
   integer :: j,k,ielem,jkoff,nn

--- a/src/gnome/gronor_gntwo.F90
+++ b/src/gnome/gronor_gntwo.F90
@@ -37,9 +37,10 @@ module gronor_gntwo_mod
   use iso_c_binding, only : c_loc, c_ptr
   use openacc
   use cuda_functions
+  use cidef
   implicit none
 contains
-subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
+subroutine gronor_gntwo(aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
   implicit none
 
@@ -47,7 +48,7 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
   external :: timer_start,timer_stop
 
-  integer :: lfndbg,i,ii,jj,k,l,n,kl,intg
+  integer :: i,ii,jj,k,l,n,kl,intg
 
   real(kind=8) :: e2n,tsn,sum2,ts,fourdet
 
@@ -296,7 +297,7 @@ subroutine gronor_gntwo(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
   return
 end subroutine gronor_gntwo
 
-subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
+  subroutine gronor_gntwo_canonical(aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdiag)
 
   use mpi
   use cidist
@@ -311,6 +312,7 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
   use cuda_functions
 #endif
 #endif
+  use cidef
 
   implicit none
 
@@ -318,7 +320,7 @@ subroutine gronor_gntwo_canonical(lfndbg,aat,aaa,tt,ta,sm,diag,bdiag,bsdiag,csdi
 
   external :: timer_start,timer_stop
 
-  integer :: lfndbg,i,k,l,n,kl,intg,intl,ls
+  integer :: i,k,l,n,kl,intg,intl,ls
   !     integer :: ii,jj
 
   real(kind=8) :: sum1,sum2,ts,fourdet

--- a/src/gnome/gronor_moover.F90
+++ b/src/gnome/gronor_moover.F90
@@ -26,9 +26,10 @@ module gronor_moover_mod
   use gnome_parameters
   use gnome_data
   use omp_lib
+  use cidef
   implicit none
 contains
-subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
+subroutine gronor_moover(va,vb,tb,ta,a)
 
   implicit none
 
@@ -36,7 +37,7 @@ subroutine gronor_moover(lfndbg,va,vb,tb,ta,a)
 
   external :: gronor_abort
 
-  integer :: lfndbg,i,nopala,nopalb,nalfab,i1,i2
+  integer :: i,nopala,nopalb,nalfab,i1,i2
   integer :: ib,kb,iv,ie,ke,le,kk,ii,k,l,m1
   integer :: imax,jmax,iout,jout
   real (kind=8) :: sum

--- a/src/gnome/gronor_tramat2.F90
+++ b/src/gnome/gronor_tramat2.F90
@@ -23,16 +23,16 @@ module gronor_tramat2_mod
   use cidist
   use gnome_parameters
   use gnome_data
+  use cidef
   implicit none
 contains
-subroutine gronor_tramat2(lfndbg,va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
+subroutine gronor_tramat2(va,vb,ta,aaa,w1,w2,diag,bdiag,bsdiag,cdiag,csdiag,sdiag)
 
   !      Transformation of the  m.o.'s
   !      the new  m.o.'s are adapted to the basis set of the two electon
   !      integrals
 
   implicit none
-  integer :: lfndbg
   real (kind=8), intent(inout) :: va(:,:),vb(:,:),ta(:,:),aaa(:,:),w1(:),w2(:,:),diag(:),bdiag(:),bsdiag(:),cdiag(:),csdiag(:),sdiag(:)
 
   integer :: i,j,k,kk,m1

--- a/src/gnome/gronor_tranout.F90
+++ b/src/gnome/gronor_tranout.F90
@@ -19,12 +19,13 @@
 !! @date    2016
 !!
 
-subroutine gronor_tranout(lfndbg,idet)
+subroutine gronor_tranout(idet)
   use cidist
   use gnome_parameters
   use gnome_data
+  use cidef
   implicit none
-  integer, intent(in) :: lfndbg,idet
+  integer, intent(in) :: idet
   integer :: ivc,ntvc,ibas,i
 
   ntvc=ntcl(idet)+ntop(idet)

--- a/src/gnome/gronor_transvc.F90
+++ b/src/gnome/gronor_transvc.F90
@@ -32,15 +32,16 @@
 !! @date    2016
 !!
 
-subroutine gronor_transvc(lfndbg, idet)
-  
+subroutine gronor_transvc(idet)
+
   use cidist
   use gnome_data
   use gnome_parameters
-  
+  use cidef
+
   implicit none
 
-  integer, intent(in) :: lfndbg, idet
+  integer, intent(in) :: idet
   integer :: m,n1,iop,ib,iv,k,i,l,im,ls,norbs
   if(idbg.ge.17) write(lfndbg,601)
 601 format(/,' Determinant Irrep  Nclose  Nopen OccActive',/)


### PR DESCRIPTION
## Summary
- Use thread-private `lfndbg` from `cidef` across gnome routines instead of passing it as an argument
- Update `gronor_gnome` and `gronor_calculate` call sites accordingly

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b2990afc832a940251fb1852d947