### PR TITLE
Handle HDF5 root via CMP0074 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ message (STATUS "CMake Version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${
 
 project (GronOR VERSION 25.03 LANGUAGES Fortran C CXX)
 
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+set(HDF5_ROOT $ENV{HDF5_ROOT} CACHE PATH "Path to HDF5 installation")
+
 # CMake optional parameters with defaults
 #    Note: MPI is not optional and removed from options list
 


### PR DESCRIPTION
## Summary
- Set CMake policy CMP0074 to NEW so `HDF5_ROOT` is honored
- Expose `HDF5_ROOT` cache variable based on environment

## Testing
- `cmake -S . -B build -DDEBUG=ON` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_68999463e910832ab278c3c6225a982e