### PR TITLE
Fix cuBLAS GEMM call with device arrays

### DIFF
--- a/src/gnome/gronor_gntwo.F90
+++ b/src/gnome/gronor_gntwo.F90
@@ -55,7 +55,7 @@ subroutine gronor_gntwo(lfndbg)
   real (kind=4)      :: e2t,tst
   real (kind=4)      :: aai,abi,bai,bbi,aak,abk,bak,bbk
   real (kind=4)      :: aaj,abj,baj,bbj,aal,abl,bal,bbl
-  real (kind=4), allocatable :: gmat(:,:),pmat(:,:),cmat(:,:)
+  real (kind=4), device, allocatable :: gmat(:,:),pmat(:,:),cmat(:,:)
   real (kind=4)      :: valg,valp
 #else
   real(kind=c_double) :: alpha, beta
@@ -63,7 +63,7 @@ subroutine gronor_gntwo(lfndbg)
   real (kind=8)       :: e2t,tst
   real (kind=8)       :: aai,abi,bai,bbi,aak,abk,bak,bbk
   real (kind=8)       :: aaj,abj,baj,bbj,aal,abl,bal,bbl
-  real (kind=8), allocatable :: gmat(:,:),pmat(:,:),cmat(:,:)
+  real (kind=8), device, allocatable :: gmat(:,:),pmat(:,:),cmat(:,:)
   real (kind=8)       :: valg,valp
 #endif
 
@@ -134,7 +134,6 @@ subroutine gronor_gntwo(lfndbg)
     pmat=0.0
     cmat=0.0
 
-!$acc enter data create(gmat,pmat,cmat)
 !$acc parallel loop gang &
 !$acc   present(aat,aaa,tt,ta,sm,g,lab,ndx,gmat,pmat)
     do ii=intndx,jntndx
@@ -163,19 +162,14 @@ subroutine gronor_gntwo(lfndbg)
 #ifdef SINGLEP
     alpha = 1.0
     beta  = 0.0
-#else
-    alpha = 1.0d0
-    beta  = 0.0d0
-#endif
-!$acc host_data use_device(gmat,pmat,cmat)
-#ifdef SINGLEP
     istat = cublasSgemm_v2(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_T, &
          nrow, nrow, ncol, alpha, gmat, nrow, pmat, nrow, beta, cmat, nrow)
 #else
+    alpha = 1.0d0
+    beta  = 0.0d0
     istat = cublasDgemm_v2(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_T, &
          nrow, nrow, ncol, alpha, gmat, nrow, pmat, nrow, beta, cmat, nrow)
 #endif
-!$acc end host_data
     istat = cublasDestroy(cublas_handle)
 
     sum2=0.0d0
@@ -188,7 +182,6 @@ subroutine gronor_gntwo(lfndbg)
     tst=ts+sum2
     ts=tst
 
-!$acc exit data delete(gmat,pmat,cmat,kl,intndx,jntndx)
     deallocate(gmat,pmat,cmat)
 
     call timer_stop(31)


### PR DESCRIPTION
## Summary
- Declare gmat, pmat, cmat with the `device` attribute so the NVHPC compiler can resolve `cublasDgemm_v2`
- Remove unnecessary OpenACC data directives and host_data wrapper, calling cuBLAS directly on device arrays

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca8236460832a91f82383559b9801