### PR TITLE
Use c_bool for HDF5 link-exists flag

### DIFF
--- a/src/gnome/debug_hdf5.F90
+++ b/src/gnome/debug_hdf5.F90
@@ -1,6 +1,7 @@
 #ifdef DEBUG_HDF5
 module debug_hdf5
   use iso_fortran_env, only: int32
+  use, intrinsic :: iso_c_binding, only: c_bool
   use hdf5
   implicit none
   integer(HID_T) :: dbg_file = -1_HID_T
@@ -33,7 +34,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
-    logical :: ex
+    logical(c_bool) :: ex
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -75,7 +76,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
-    logical :: ex
+    logical(c_bool) :: ex
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -116,7 +117,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, value32, rank32
-    logical :: ex
+    logical(c_bool) :: ex
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -158,7 +159,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
-    logical :: ex
+    logical(c_bool) :: ex
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
     integer(int32) :: arr32(size(arr))
 
@@ -200,7 +201,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, dtype, attr_space, attr
     integer(int32) :: ierr, rank32
-    logical :: ex
+    logical(c_bool) :: ex
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
     integer(SIZE_T) :: len
 


### PR DESCRIPTION
## Summary
- Import `iso_c_binding` to use `c_bool` in HDF5 debug utilities
- Declare `ex` as `logical(c_bool)` to satisfy `h5lexists_f`

## Testing
- `cmake -S . -B build -DOPENMP=OFF -DMKL=OFF -DACC=OFF` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_689dac09ca0c832a9dc5a7efd96902f6