### PR TITLE
fix: align debug HDF5 integer kinds

### DIFF
--- a/src/gnome/debug_hdf5.F90
+++ b/src/gnome/debug_hdf5.F90
@@ -5,12 +5,12 @@ module debug_hdf5
   use h5lt
   implicit none
   integer(HID_T) :: dbg_file = -1_HID_T
-  integer :: dbg_level = 0
-  integer :: dbg_rank = -1
+  integer(int32) :: dbg_level = 0
+  integer(int32) :: dbg_rank = -1
 contains
   subroutine dbg_open(filename, level, rank)
     character(len=*), intent(in) :: filename
-    integer, intent(in) :: level, rank
+    integer(int32), intent(in) :: level, rank
     integer(int32) :: ierr
     dbg_level = level
     dbg_rank = rank
@@ -51,7 +51,7 @@ contains
 
     dims(1) = 1_HSIZE_T
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    call h5ltfind_dataset_f(grp, trim(dset_name), exists, ierr)
+    exists = h5ltfind_dataset_f(grp, trim(dset_name))
     if (exists == 0) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
     else
@@ -96,7 +96,7 @@ contains
 
     dims(1) = int(size(arr), HSIZE_T)
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    call h5ltfind_dataset_f(grp, trim(dset_name), exists, ierr)
+    exists = h5ltfind_dataset_f(grp, trim(dset_name))
     if (exists == 0) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
     else
@@ -118,11 +118,11 @@ contains
 
   subroutine dbg_write_int_scalar(group, name, value, step)
     character(len=*), intent(in) :: group, name
-    integer, intent(in) :: value
+    integer(int32), intent(in) :: value
     integer, intent(in), optional :: step
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer(int32) :: ierr, value32, rank32
+    integer(int32) :: ierr, rank32
     integer :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
@@ -140,14 +140,13 @@ contains
 
     dims(1) = 1_HSIZE_T
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    call h5ltfind_dataset_f(grp, trim(dset_name), exists, ierr)
+    exists = h5ltfind_dataset_f(grp, trim(dset_name))
     if (exists == 0) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
     end if
-    value32 = int(value, int32)
-    call h5dwrite_f(dset, H5T_NATIVE_INTEGER, value32, dims, ierr)
+    call h5dwrite_f(dset, H5T_NATIVE_INTEGER, value, dims, ierr)
     call h5sclose_f(space, ierr)
 
     call h5screate_simple_f(1_int32, dims, attr_space, ierr)
@@ -163,14 +162,13 @@ contains
 
   subroutine dbg_write_int_array(group, name, arr, step)
     character(len=*), intent(in) :: group, name
-    integer, intent(in) :: arr(:)
+    integer(int32), intent(in) :: arr(:)
     integer, intent(in), optional :: step
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
     integer :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
-    integer(int32) :: arr32(size(arr))
 
     if (dbg_file .lt. 0) return
     if (present(step)) then
@@ -186,14 +184,13 @@ contains
 
     dims(1) = int(size(arr), HSIZE_T)
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    call h5ltfind_dataset_f(grp, trim(dset_name), exists, ierr)
+    exists = h5ltfind_dataset_f(grp, trim(dset_name))
     if (exists == 0) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
     end if
-    arr32 = int(arr, int32)
-    call h5dwrite_f(dset, H5T_NATIVE_INTEGER, arr32, dims, ierr)
+    call h5dwrite_f(dset, H5T_NATIVE_INTEGER, arr, dims, ierr)
     call h5sclose_f(space, ierr)
 
     call h5screate_simple_f(1_int32, (/1_HSIZE_T/), attr_space, ierr)
@@ -234,7 +231,7 @@ contains
     call h5screate_simple_f(1_int32, dims, space, ierr)
     call h5tcopy_f(H5T_C_S1, dtype, ierr)
     call h5tset_size_f(dtype, len, ierr)
-    call h5ltfind_dataset_f(grp, trim(dset_name), exists, ierr)
+    exists = h5ltfind_dataset_f(grp, trim(dset_name))
     if (exists == 0) then
       call h5dcreate_f(grp, trim(dset_name), dtype, space, dset, ierr)
     else

--- a/src/gnome/gronor_calculate.F90
+++ b/src/gnome/gronor_calculate.F90
@@ -38,6 +38,7 @@ subroutine gronor_calculate(ib,jb,id1,id2)
 #ifdef DEBUG_HDF5
   use debug_hdf5
 #endif
+  use iso_fortran_env, only: int32
 
 #ifdef _OPENMP
   use omp_lib
@@ -73,13 +74,13 @@ subroutine gronor_calculate(ib,jb,id1,id2)
   if(idbg.ge.50) then
     write(msg,'("Starting gronor_calculate ib=",i0," jb=",i0," id1=",i0," id2=",i0)') ib,jb,id1,id2
     call dbg_log_msg('calculate', trim(msg))
-    call dbg_write_int_scalar('calculate','ib',ib)
-    call dbg_write_int_scalar('calculate','jb',jb)
-    call dbg_write_int_scalar('calculate','id1',id1)
-    call dbg_write_int_scalar('calculate','id2',id2)
-    call dbg_write_int_scalar('calculate','ndeti',ndeti)
+    call dbg_write_int_scalar('calculate','ib',int(ib,int32))
+    call dbg_write_int_scalar('calculate','jb',int(jb,int32))
+    call dbg_write_int_scalar('calculate','id1',int(id1,int32))
+    call dbg_write_int_scalar('calculate','id2',int(id2,int32))
+    call dbg_write_int_scalar('calculate','ndeti',int(ndeti,int32))
     call dbg_write_array('calculate','civb_left',civb(1:ndeti,ib))
-    call dbg_write_int_scalar('calculate','ndetj',ndetj)
+    call dbg_write_int_scalar('calculate','ndetj',int(ndetj,int32))
     call dbg_write_array('calculate','civb_right',civb(1:ndetj,jb))
   endif
 #endif
@@ -127,7 +128,7 @@ subroutine gronor_calculate(ib,jb,id1,id2)
     call timer_start(5)
 
 #ifdef DEBUG_HDF5
-    if(idbg.ge.50) call dbg_write_int_scalar('calculate','matrix_element',ij,step=ij)
+    if(idbg.ge.50) call dbg_write_int_scalar('calculate','matrix_element',int(ij,int32),step=ij)
 #endif
 
     nelec(1)=0
@@ -216,8 +217,8 @@ subroutine gronor_calculate(ib,jb,id1,id2)
       
 #ifdef DEBUG_HDF5
       if(idbg.ge.40) then
-        call dbg_write_int_array('calculate','ioccup_left',ioccup(1:nact(1),1))
-        call dbg_write_int_array('calculate','ioccup_right',ioccup(1:nact(2),2))
+        call dbg_write_int_array('calculate','ioccup_left',int(ioccup(1:nact(1),1),int32))
+        call dbg_write_int_array('calculate','ioccup_right',int(ioccup(1:nact(2),2),int32))
       endif
 #endif
 

--- a/src/gnome/gronor_gnome.F90
+++ b/src/gnome/gronor_gnome.F90
@@ -30,6 +30,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc)
 #ifdef DEBUG_HDF5
   use debug_hdf5
 #endif
+  use iso_fortran_env, only: int32
   !      use nvtx
 
   implicit none
@@ -71,8 +72,8 @@ subroutine gronor_gnome(lfndbg,ihc,nhc)
   
 #ifdef DEBUG_HDF5
   if(idbg.ge.20) then
-    call dbg_write_int_scalar('gnome','nbasis',nbasis)
-    call dbg_write_int_scalar('gnome','nelec',nelec(1))
+    call dbg_write_int_scalar('gnome','nbasis',int(nbasis,int32))
+    call dbg_write_int_scalar('gnome','nelec',int(nelec(1),int32))
   endif
 #endif
 
@@ -81,8 +82,8 @@ subroutine gronor_gnome(lfndbg,ihc,nhc)
     
 #ifdef DEBUG_HDF5
     if(idbg.ge.20) then
-      call dbg_write_int_scalar('gnome','idet',idet,step=idet)
-      call dbg_write_int_array('gnome','ioccup',ioccup(1:nact(idet),idet),step=idet)
+      call dbg_write_int_scalar('gnome','idet',int(idet,int32),step=idet)
+      call dbg_write_int_array('gnome','ioccup',int(ioccup(1:nact(idet),idet),int32),step=idet)
     endif
 #endif
 
@@ -116,10 +117,10 @@ subroutine gronor_gnome(lfndbg,ihc,nhc)
 
 #ifdef DEBUG_HDF5
   if(idbg.ge.20) then
-    call dbg_write_int_scalar('gnome','ntcla',ntcla)
-    call dbg_write_int_scalar('gnome','ntclb',ntclb)
-    call dbg_write_int_scalar('gnome','nveca',nveca)
-    call dbg_write_int_scalar('gnome','nvecb',nvecb)
+    call dbg_write_int_scalar('gnome','ntcla',int(ntcla,int32))
+    call dbg_write_int_scalar('gnome','ntclb',int(ntclb,int32))
+    call dbg_write_int_scalar('gnome','nveca',int(nveca,int32))
+    call dbg_write_int_scalar('gnome','nvecb',int(nvecb,int32))
   endif
 #endif
 
@@ -139,7 +140,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc)
     do idet=1,2
       ntvc=ntcl(idet)+ntop(idet)
       call dbg_log_msg('gnome','Closed shell M.O.s',step=idet)
-      call dbg_write_int_scalar('gnome','ntvc',ntvc,step=idet)
+      call dbg_write_int_scalar('gnome','ntvc',int(ntvc,int32),step=idet)
       do ivc=1,ntvc
         if(ivc.eq.ntcl(idet)+1) call dbg_log_msg('gnome','Open shell M.O.s:',step=idet)
         if(idbg.gt.90.or.ivc.lt.11.or.ivc.gt.ntvc-10) then
@@ -162,7 +163,7 @@ subroutine gronor_gnome(lfndbg,ihc,nhc)
   enddo
 
 #ifdef DEBUG_HDF5
-  if(idbg.ge.10) call dbg_write_int_scalar('gnome','iamacc',iamacc)
+  if(idbg.ge.10) call dbg_write_int_scalar('gnome','iamacc',int(iamacc,int32))
 #endif
 
   if(iamacc.gt.0) then

--- a/src/gnome/gronor_main.F90
+++ b/src/gnome/gronor_main.F90
@@ -825,7 +825,7 @@ subroutine gronor_main()
   if(idbg.gt.0) then
     write(fildbg,1300) trim(string),me
 1300 format(a,'-',i5.5,'.dbg ')
-    call dbg_open(trim(fildbg)//'.h5', idbg, me)
+    call dbg_open(trim(fildbg)//'.h5', int(idbg,int32), int(me,int32))
     call swatch(date,time)
     write(msg,'("Debug start at ",a,1x,a,": rank=",i6,", idbg=",i6)') &
         date(1:8),time(1:8),me,idbg
@@ -1695,10 +1695,10 @@ subroutine gronor_main()
       write(msg,'("Base state ",i0," recorded at ",a,1x,a)') i,date(1:8),time(1:8)
       call dbg_log_msg('main',trim(msg))
       ndeti=idetb(i)
-      call dbg_write_int_scalar('main','ndeti',ndeti,step=i)
+      call dbg_write_int_scalar('main','ndeti',int(ndeti,int32),step=i)
       do ib=1,ndeti
         call dbg_write_scalar('main','civb',civb(ib,i),step=ib)
-        call dbg_write_int_array('main','iocc',iocc(ib,i,1:nactb(i)),step=ib)
+        call dbg_write_int_array('main','iocc',int(iocc(ib,i,1:nactb(i)),int32),step=ib)
       enddo
       do ivc=1,nactb(i)+inactb(i)
         if(idbg.gt.90.or.ivc.lt.11.or.ivc.gt.nactb(i)+inactb(i)-10) then
@@ -2016,12 +2016,12 @@ subroutine gronor_main()
         numdev,mydev,iamacc,nummps,numgpu,date(1:8),time(1:8)
 #endif
     call dbg_log_msg('main',trim(msg))
-    call dbg_write_int_scalar('main','numdev',numdev)
-    call dbg_write_int_scalar('main','mydev',mydev)
-    call dbg_write_int_scalar('main','iamacc',iamacc)
-    call dbg_write_int_scalar('main','nummps',nummps)
-    call dbg_write_int_scalar('main','numgpu',numgpu)
-    call dbg_write_int_array('main','map2',map2(me+1,1:5))
+    call dbg_write_int_scalar('main','numdev',int(numdev,int32))
+    call dbg_write_int_scalar('main','mydev',int(mydev,int32))
+    call dbg_write_int_scalar('main','iamacc',int(iamacc,int32))
+    call dbg_write_int_scalar('main','nummps',int(nummps,int32))
+    call dbg_write_int_scalar('main','numgpu',int(numgpu,int32))
+    call dbg_write_int_array('main','map2',int(map2(me+1,1:5),int32))
     call swatch(date,time)
     write(msg,'("Start memory/master at ",a,1x,a)') date(1:8),time(1:8)
     call dbg_log_msg('main',trim(msg))
@@ -2127,7 +2127,7 @@ subroutine gronor_main()
       if(iamacc.eq.1) then
 #ifdef DEBUG_HDF5
         if(idbg.gt.0) then
-          call dbg_write_scalar('main','mint2',mint2)
+          call dbg_write_int_scalar('main','mint2',int(mint2,int32))
         endif
 #endif
 

--- a/src/gnome/gronor_makebasestate.F90
+++ b/src/gnome/gronor_makebasestate.F90
@@ -50,6 +50,7 @@ use cidef
 #ifdef DEBUG_HDF5
 use debug_hdf5, only : dbg_write_scalar, dbg_write_int_scalar, dbg_log_msg
 #endif
+use iso_fortran_env, only: int32
 
 implicit none
 
@@ -293,7 +294,7 @@ do iFrag=2,nmol
 #ifdef DEBUG_HDF5
   if(idbg.ge.20) then
     if(nmol .gt. 2) then
-      call dbg_write_int_scalar('makebasestate','target_spin',target_spin)
+      call dbg_write_int_scalar('makebasestate','target_spin',int(target_spin,int32))
     endif
   endif
 #endif
@@ -328,7 +329,7 @@ do iFrag=2,nmol
 
 #ifdef DEBUG_HDF5
   if(idbg.ge.20) then
-    call dbg_write_int_scalar('makebasestate','newdets',newdets)
+    call dbg_write_int_scalar('makebasestate','newdets',int(newdets,int32))
   endif
 #endif
 ! create the new intermediate occupations and coefficients

--- a/src/gnome/gronor_manager.F90
+++ b/src/gnome/gronor_manager.F90
@@ -27,6 +27,7 @@ subroutine gronor_manager()
 #ifdef DEBUG_HDF5
   use debug_hdf5
 #endif
+  use iso_fortran_env, only: int32
 
   implicit none
 
@@ -101,7 +102,7 @@ subroutine gronor_manager()
       write(msg,'(i5,a,i5,a,i5,a,i5)') me,' received task from ',mstr, &
           ' tag ',mpitag,' ierr ',ierr
       call dbg_log_msg('manager',trim(date)//' '//trim(time)//' '//trim(msg),step=istep)
-      call dbg_write_int_array('manager','ibuf_in',ibuf,step=istep)
+      call dbg_write_int_array('manager','ibuf_in',int(ibuf,int32),step=istep)
     endif
 #endif
 
@@ -249,7 +250,7 @@ subroutine gronor_manager()
       write(msg,'(i5,a,i5)') me,' sent results to ',mstr
       call dbg_log_msg('manager',trim(date)//' '//trim(time)//' '//trim(msg),step=istep)
       call dbg_write_array('manager','tbuf',tbuf,step=istep)
-      call dbg_write_int_array('manager','ibuf_out',ibuf,step=istep)
+      call dbg_write_int_array('manager','ibuf_out',int(ibuf,int32),step=istep)
     endif
 #endif
     do i=1,17

--- a/src/gnome/gronor_master.F90
+++ b/src/gnome/gronor_master.F90
@@ -40,6 +40,7 @@ subroutine gronor_master()
 #ifdef DEBUG_HDF5
   use debug_hdf5
 #endif
+  use iso_fortran_env, only: int32
 
   implicit none
 
@@ -742,7 +743,7 @@ subroutine gronor_master()
           call swatch(date,time)
           write(msg,'(a,1x,a,1x,"sent task to ",i5)') date(1:8),time(1:8),iremote
           call dbg_log_msg('master',trim(msg),step=send_step)
-          call dbg_write_int_array('master','ibuf',int(ipbuf(:,iremote+1)),step=send_step)
+          call dbg_write_int_array('master','ibuf',int(ipbuf(:,iremote+1),int32),step=send_step)
         endif
 #endif
 
@@ -1121,7 +1122,7 @@ subroutine gronor_master()
             call swatch(date,time)
             write(msg,'(a,1x,a,1x,"sent duplicate to ",i5)') date(1:8),time(1:8),iremote
             call dbg_log_msg('master',trim(msg),step=send_step)
-            call dbg_write_int_array('master','ibuf',int(ipbuf(:,iremote+1)),step=send_step)
+            call dbg_write_int_array('master','ibuf',int(ipbuf(:,iremote+1),int32),step=send_step)
           endif
 #endif
 
@@ -1229,7 +1230,7 @@ subroutine gronor_master()
       call swatch(date,time)
       write(msg,'(a,1x,a,1x,"sent termination to ",i5)') date(1:8),time(1:8),iremote
       call dbg_log_msg('master',trim(msg),step=send_step)
-      call dbg_write_int_array('master','ibuf',int(itbuf(:,iremote+1)),step=send_step)
+      call dbg_write_int_array('master','ibuf',int(itbuf(:,iremote+1),int32),step=send_step)
     endif
 #endif
 
@@ -1254,7 +1255,7 @@ subroutine gronor_master()
           call swatch(date,time)
           write(msg,'(a,1x,a,1x,"sent termination to ",i5)') date(1:8),time(1:8),iremote
           call dbg_log_msg('master',trim(msg),step=send_step)
-          call dbg_write_int_array('master','ibuf',int(itbuf(:,iremote+1)),step=send_step)
+          call dbg_write_int_array('master','ibuf',int(itbuf(:,iremote+1),int32),step=send_step)
         endif
 #endif
       endif

--- a/src/gnome/gronor_moover.F90
+++ b/src/gnome/gronor_moover.F90
@@ -29,6 +29,7 @@ subroutine gronor_moover(lfndbg)
 #ifdef DEBUG_HDF5
   use debug_hdf5
 #endif
+  use iso_fortran_env, only: int32
 
   implicit none
 
@@ -60,10 +61,10 @@ subroutine gronor_moover(lfndbg)
 
 #ifdef DEBUG_HDF5
   if(idbg.ge.13) then
-    call dbg_write_int_scalar('moover','nopala',nopala)
-    call dbg_write_int_scalar('moover','nopalb',nopalb)
-    call dbg_write_int_scalar('moover','nalfa',nalfa)
-    call dbg_write_int_scalar('moover','nalfab',nalfab)
+    call dbg_write_int_scalar('moover','nopala',int(nopala,int32))
+    call dbg_write_int_scalar('moover','nopalb',int(nopalb,int32))
+    call dbg_write_int_scalar('moover','nalfa',int(nalfa,int32))
+    call dbg_write_int_scalar('moover','nalfab',int(nalfab,int32))
   endif
   if(idbg.ge.14) call dbg_log_msg('moover','overlap matrix setup')
 #endif

--- a/src/gnome/gronor_tranout.F90
+++ b/src/gnome/gronor_tranout.F90
@@ -26,6 +26,7 @@ subroutine gronor_tranout(lfndbg,idet)
 #ifdef DEBUG_HDF5
   use debug_hdf5
 #endif
+  use iso_fortran_env, only: int32
   implicit none
   integer :: idet, lfndbg
   integer :: ivc,ntvc,ibas,i
@@ -35,8 +36,8 @@ subroutine gronor_tranout(lfndbg,idet)
   
 #ifdef DEBUG_HDF5
   if(idbg.ge.25) then
-    call dbg_write_int_scalar('tranout','nclose',ntcl(idet))
-    call dbg_write_int_scalar('tranout','nopen',ntop(idet))
+    call dbg_write_int_scalar('tranout','nclose',int(ntcl(idet),int32))
+    call dbg_write_int_scalar('tranout','nopen',int(ntop(idet),int32))
     call dbg_log_msg('tranout','M.O.s transformed and ordered')
   endif
 #endif

--- a/src/gnome/gronor_worker.F90
+++ b/src/gnome/gronor_worker.F90
@@ -28,6 +28,7 @@ subroutine gronor_worker()
 #ifdef DEBUG_HDF5
   use debug_hdf5
 #endif
+  use iso_fortran_env, only: int32
 
   implicit none
 
@@ -175,7 +176,7 @@ subroutine gronor_worker_process()
     call swatch(date,time)
     write(msg,'(a,1x,a,1x,"thisgroup=")') date(1:8),time(1:8)
     call dbg_log_msg('worker',trim(msg))
-    call dbg_write_int_array('worker','thisgroup',thisgroup(1:mgr+1))
+    call dbg_write_int_array('worker','thisgroup',int(thisgroup(1:mgr+1),int32))
     call dbg_write_array('worker','rbuf',rbuf)
   endif
 #endif
@@ -275,7 +276,7 @@ subroutine gronor_worker_process()
     if(idbg.gt.0) then
       write(msg,'("ibuf=",4i8)') (ibuf(i),i=1,4)
       call dbg_log_msg('worker', trim(msg), step=iter)
-      call dbg_write_int_array('worker','ibuf',ibuf,step=iter)
+      call dbg_write_int_array('worker','ibuf',int(ibuf,int32),step=iter)
     endif
 #endif
 


### PR DESCRIPTION
## Summary
- standardize debug HDF5 helpers on 32-bit integers and call `h5ltfind_dataset_f` as a function
- cast debug integer data to `int32` across gnome sources
- use integer-specific debug writer for `mint2`

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a2a18956c0832a87235278d23ca7a3