### PR TITLE
Use logical exists for HDF5 dataset checks

### DIFF
--- a/src/gnome/debug_hdf5.F90
+++ b/src/gnome/debug_hdf5.F90
@@ -1,8 +1,8 @@
 #ifdef DEBUG_HDF5
 module debug_hdf5
   use iso_fortran_env, only: int32
+  use iso_c_binding, only: c_bool
   use hdf5
-  use h5lt
   implicit none
   integer(HID_T) :: dbg_file = -1_HID_T
   integer(int32) :: dbg_level = 0
@@ -34,7 +34,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
-    integer :: exists
+    logical(c_bool) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -51,8 +51,8 @@ contains
 
     dims(1) = 1_HSIZE_T
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -79,7 +79,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
-    integer :: exists
+    logical(c_bool) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -96,8 +96,8 @@ contains
 
     dims(1) = int(size(arr), HSIZE_T)
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -123,7 +123,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
-    integer :: exists
+    logical(c_bool) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -140,8 +140,8 @@ contains
 
     dims(1) = 1_HSIZE_T
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -167,7 +167,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
     integer(int32) :: ierr, rank32
-    integer :: exists
+    logical(c_bool) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -184,8 +184,8 @@ contains
 
     dims(1) = int(size(arr), HSIZE_T)
     call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -210,7 +210,7 @@ contains
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, dtype, attr_space, attr
     integer(int32) :: ierr, rank32
-    integer :: exists
+    logical(c_bool) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
     integer(SIZE_T) :: len
 
@@ -231,8 +231,8 @@ contains
     call h5screate_simple_f(1_int32, dims, space, ierr)
     call h5tcopy_f(H5T_C_S1, dtype, ierr)
     call h5tset_size_f(dtype, len, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), dtype, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)


### PR DESCRIPTION
## Summary
- avoid kind mismatches by declaring dataset existence flag as `logical(c_bool)`
- use `h5lexists_f` with logical checks instead of integer compares

## Testing
- `cmake -S . -B build -DMPI=OFF` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a83804832aabb4b4c5b2b582bf