### PR TITLE
Refactor debug HDF5 module to drop int32 kind

### DIFF
--- a/src/gnome/debug_hdf5.F90
+++ b/src/gnome/debug_hdf5.F90
@@ -1,17 +1,15 @@
 #ifdef DEBUG_HDF5
 module debug_hdf5
-  use iso_fortran_env, only: int32
   use hdf5
-  use h5lt
   implicit none
   integer(HID_T) :: dbg_file = -1_HID_T
-  integer(int32) :: dbg_level = 0
-  integer(int32) :: dbg_rank = -1
+  integer :: dbg_level = 0
+  integer :: dbg_rank = -1
 contains
   subroutine dbg_open(filename, level, rank)
     character(len=*), intent(in) :: filename
-    integer(int32), intent(in) :: level, rank
-    integer(int32) :: ierr
+    integer, intent(in) :: level, rank
+    integer :: ierr
     dbg_level = level
     dbg_rank = rank
     call h5open_f(ierr)
@@ -19,7 +17,7 @@ contains
   end subroutine dbg_open
 
   subroutine dbg_close()
-    integer(int32) :: ierr
+    integer :: ierr
     if (dbg_file .ge. 0) then
       call h5fclose_f(dbg_file, ierr)
       dbg_file = -1_HID_T
@@ -33,8 +31,8 @@ contains
     integer, intent(in), optional :: step
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer(int32) :: ierr, rank32
-    integer :: exists
+    integer :: ierr
+    logical(kind=4) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -50,9 +48,9 @@ contains
     end if
 
     dims(1) = 1_HSIZE_T
-    call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5screate_simple_f(1, dims, space, ierr)
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -61,10 +59,9 @@ contains
     call h5sclose_f(space, ierr)
 
     ! rank attribute
-    call h5screate_simple_f(1_int32, dims, attr_space, ierr)
+    call h5screate_simple_f(1, dims, attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
-    rank32 = int(dbg_rank, int32)
-    call h5awrite_f(attr, H5T_NATIVE_INTEGER, rank32, adims, ierr)
+    call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
     call h5sclose_f(attr_space, ierr)
 
@@ -78,8 +75,8 @@ contains
     integer, intent(in), optional :: step
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer(int32) :: ierr, rank32
-    integer :: exists
+    integer :: ierr
+    logical(kind=4) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -95,9 +92,9 @@ contains
     end if
 
     dims(1) = int(size(arr), HSIZE_T)
-    call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5screate_simple_f(1, dims, space, ierr)
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -105,10 +102,9 @@ contains
     call h5dwrite_f(dset, H5T_NATIVE_DOUBLE, arr, dims, ierr)
     call h5sclose_f(space, ierr)
 
-    call h5screate_simple_f(1_int32, (/1_HSIZE_T/), attr_space, ierr)
+    call h5screate_simple_f(1, (/1_HSIZE_T/), attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
-    rank32 = int(dbg_rank, int32)
-    call h5awrite_f(attr, H5T_NATIVE_INTEGER, rank32, adims, ierr)
+    call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
     call h5sclose_f(attr_space, ierr)
 
@@ -118,12 +114,12 @@ contains
 
   subroutine dbg_write_int_scalar(group, name, value, step)
     character(len=*), intent(in) :: group, name
-    integer(int32), intent(in) :: value
+    integer, intent(in) :: value
     integer, intent(in), optional :: step
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer(int32) :: ierr, rank32
-    integer :: exists
+    integer :: ierr
+    logical(kind=4) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -139,9 +135,9 @@ contains
     end if
 
     dims(1) = 1_HSIZE_T
-    call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5screate_simple_f(1, dims, space, ierr)
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -149,10 +145,9 @@ contains
     call h5dwrite_f(dset, H5T_NATIVE_INTEGER, value, dims, ierr)
     call h5sclose_f(space, ierr)
 
-    call h5screate_simple_f(1_int32, dims, attr_space, ierr)
+    call h5screate_simple_f(1, dims, attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
-    rank32 = int(dbg_rank, int32)
-    call h5awrite_f(attr, H5T_NATIVE_INTEGER, rank32, adims, ierr)
+    call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
     call h5sclose_f(attr_space, ierr)
 
@@ -162,12 +157,12 @@ contains
 
   subroutine dbg_write_int_array(group, name, arr, step)
     character(len=*), intent(in) :: group, name
-    integer(int32), intent(in) :: arr(:)
+    integer, intent(in) :: arr(:)
     integer, intent(in), optional :: step
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer(int32) :: ierr, rank32
-    integer :: exists
+    integer :: ierr
+    logical(kind=4) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
 
     if (dbg_file .lt. 0) return
@@ -183,9 +178,9 @@ contains
     end if
 
     dims(1) = int(size(arr), HSIZE_T)
-    call h5screate_simple_f(1_int32, dims, space, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5screate_simple_f(1, dims, space, ierr)
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
@@ -193,10 +188,9 @@ contains
     call h5dwrite_f(dset, H5T_NATIVE_INTEGER, arr, dims, ierr)
     call h5sclose_f(space, ierr)
 
-    call h5screate_simple_f(1_int32, (/1_HSIZE_T/), attr_space, ierr)
+    call h5screate_simple_f(1, (/1_HSIZE_T/), attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
-    rank32 = int(dbg_rank, int32)
-    call h5awrite_f(attr, H5T_NATIVE_INTEGER, rank32, adims, ierr)
+    call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
     call h5sclose_f(attr_space, ierr)
 
@@ -209,8 +203,8 @@ contains
     integer, intent(in), optional :: step
     character(len=256) :: dset_name
     integer(HID_T) :: grp, space, dset, dtype, attr_space, attr
-    integer(int32) :: ierr, rank32
-    integer :: exists
+    integer :: ierr
+    logical(kind=4) :: exists
     integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
     integer(SIZE_T) :: len
 
@@ -228,22 +222,21 @@ contains
 
     len = int(len_trim(msg), SIZE_T)
     dims(1) = 1_HSIZE_T
-    call h5screate_simple_f(1_int32, dims, space, ierr)
+    call h5screate_simple_f(1, dims, space, ierr)
     call h5tcopy_f(H5T_C_S1, dtype, ierr)
     call h5tset_size_f(dtype, len, ierr)
-    exists = h5ltfind_dataset_f(grp, trim(dset_name))
-    if (exists == 0) then
+    call h5lexists_f(grp, trim(dset_name), exists, ierr)
+    if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), dtype, space, dset, ierr)
     else
       call h5dopen_f(grp, trim(dset_name), dset, ierr)
     end if
-    call h5dwrite_f(dset, dtype, msg(1:int(len,int32)), dims, ierr)
+    call h5dwrite_f(dset, dtype, msg(1:int(len)), dims, ierr)
 
     ! rank attribute
-    call h5screate_simple_f(1_int32, (/1_HSIZE_T/), attr_space, ierr)
+    call h5screate_simple_f(1, (/1_HSIZE_T/), attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
-    rank32 = int(dbg_rank, int32)
-    call h5awrite_f(attr, H5T_NATIVE_INTEGER, rank32, adims, ierr)
+    call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
     call h5sclose_f(attr_space, ierr)
 


### PR DESCRIPTION
## Summary
- remove `iso_fortran_env` dependency and all `int32` kinds in `debug_hdf5`
- rely on default `integer` types when creating datasets and writing rank attributes

## Testing
- `cmake -S . -B build -DMPI=OFF` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a83804832aabb4b4c5b2b582bf