### PR TITLE
Fix integer kind mismatches in HDF5 debug module

### DIFF
--- a/src/gnome/debug_hdf5.F90
+++ b/src/gnome/debug_hdf5.F90
@@ -2,40 +2,40 @@
 module debug_hdf5
   use hdf5
   implicit none
-  integer(HID_T) :: dbg_file = -1_HID_T
-  integer :: dbg_level = 0
-  integer :: dbg_rank = -1
+  integer(HID_T) :: dbg_file = 0
+  integer(kind=4) :: dbg_level = 0
+  integer(kind=4) :: dbg_rank  = 0
 contains
-  subroutine dbg_open(filename, level, rank)
+  subroutine dbg_open(filename, level, rank_in)
     character(len=*), intent(in) :: filename
-    integer, intent(in) :: level, rank
-    integer :: ierr
+    integer(kind=4), intent(in) :: level, rank_in
+    integer(kind=4) :: ierr
     dbg_level = level
-    dbg_rank = rank
+    dbg_rank  = rank_in
     call h5open_f(ierr)
     call h5fcreate_f(trim(filename), H5F_ACC_TRUNC_F, dbg_file, ierr)
   end subroutine dbg_open
 
   subroutine dbg_close()
-    integer :: ierr
-    if (dbg_file .ge. 0) then
+    integer(kind=4) :: ierr
+    if (dbg_file > 0) then
       call h5fclose_f(dbg_file, ierr)
-      dbg_file = -1_HID_T
+      dbg_file = 0
     end if
     call h5close_f(ierr)
   end subroutine dbg_close
 
   subroutine dbg_write_scalar(group, name, value, step)
     character(len=*), intent(in) :: group, name
-    real(8), intent(in) :: value
-    integer, intent(in), optional :: step
+    real(8),          intent(in) :: value
+    integer(kind=4), intent(in), optional :: step
     character(len=256) :: dset_name
-    integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer :: ierr
-    logical(kind=4) :: exists
-    integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
+    integer(HID_T)     :: grp, space, dset, attr_space, attr
+    integer(kind=4)    :: ierr
+    logical(kind=4)    :: exists
+    integer(HSIZE_T)   :: dims(1), adims(1)
 
-    if (dbg_file .lt. 0) return
+    if (dbg_file <= 0) return
     if (present(step)) then
       write(dset_name, '(a,"_step",i4.4)') trim(name), step
     else
@@ -47,8 +47,8 @@ contains
       call h5gcreate_f(dbg_file, trim(group), grp, ierr)
     end if
 
-    dims(1) = 1_HSIZE_T
-    call h5screate_simple_f(1, dims, space, ierr)
+    dims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), dims, space, ierr)
     call h5lexists_f(grp, trim(dset_name), exists, ierr)
     if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
@@ -59,7 +59,8 @@ contains
     call h5sclose_f(space, ierr)
 
     ! rank attribute
-    call h5screate_simple_f(1, dims, attr_space, ierr)
+    adims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), adims, attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
     call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
@@ -71,15 +72,15 @@ contains
 
   subroutine dbg_write_array(group, name, arr, step)
     character(len=*), intent(in) :: group, name
-    real(8), intent(in) :: arr(:)
-    integer, intent(in), optional :: step
+    real(8),          intent(in) :: arr(:)
+    integer(kind=4), intent(in), optional :: step
     character(len=256) :: dset_name
-    integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer :: ierr
-    logical(kind=4) :: exists
-    integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
+    integer(HID_T)     :: grp, space, dset, attr_space, attr
+    integer(kind=4)    :: ierr
+    logical(kind=4)    :: exists
+    integer(HSIZE_T)   :: dims(1), adims(1)
 
-    if (dbg_file .lt. 0) return
+    if (dbg_file <= 0) return
     if (present(step)) then
       write(dset_name, '(a,"_step",i4.4)') trim(name), step
     else
@@ -92,7 +93,7 @@ contains
     end if
 
     dims(1) = int(size(arr), HSIZE_T)
-    call h5screate_simple_f(1, dims, space, ierr)
+    call h5screate_simple_f(int(1,kind=4), dims, space, ierr)
     call h5lexists_f(grp, trim(dset_name), exists, ierr)
     if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_DOUBLE, space, dset, ierr)
@@ -102,7 +103,8 @@ contains
     call h5dwrite_f(dset, H5T_NATIVE_DOUBLE, arr, dims, ierr)
     call h5sclose_f(space, ierr)
 
-    call h5screate_simple_f(1, (/1_HSIZE_T/), attr_space, ierr)
+    adims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), adims, attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
     call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
@@ -114,15 +116,15 @@ contains
 
   subroutine dbg_write_int_scalar(group, name, value, step)
     character(len=*), intent(in) :: group, name
-    integer, intent(in) :: value
-    integer, intent(in), optional :: step
+    integer(kind=4), intent(in) :: value
+    integer(kind=4), intent(in), optional :: step
     character(len=256) :: dset_name
-    integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer :: ierr
-    logical(kind=4) :: exists
-    integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
+    integer(HID_T)     :: grp, space, dset, attr_space, attr
+    integer(kind=4)    :: ierr
+    logical(kind=4)    :: exists
+    integer(HSIZE_T)   :: dims(1), adims(1)
 
-    if (dbg_file .lt. 0) return
+    if (dbg_file <= 0) return
     if (present(step)) then
       write(dset_name, '(a,"_step",i4.4)') trim(name), step
     else
@@ -134,8 +136,8 @@ contains
       call h5gcreate_f(dbg_file, trim(group), grp, ierr)
     end if
 
-    dims(1) = 1_HSIZE_T
-    call h5screate_simple_f(1, dims, space, ierr)
+    dims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), dims, space, ierr)
     call h5lexists_f(grp, trim(dset_name), exists, ierr)
     if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
@@ -145,7 +147,8 @@ contains
     call h5dwrite_f(dset, H5T_NATIVE_INTEGER, value, dims, ierr)
     call h5sclose_f(space, ierr)
 
-    call h5screate_simple_f(1, dims, attr_space, ierr)
+    adims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), adims, attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
     call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
@@ -157,15 +160,15 @@ contains
 
   subroutine dbg_write_int_array(group, name, arr, step)
     character(len=*), intent(in) :: group, name
-    integer, intent(in) :: arr(:)
-    integer, intent(in), optional :: step
+    integer(kind=4), intent(in) :: arr(:)
+    integer(kind=4), intent(in), optional :: step
     character(len=256) :: dset_name
-    integer(HID_T) :: grp, space, dset, attr_space, attr
-    integer :: ierr
-    logical(kind=4) :: exists
-    integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
+    integer(HID_T)     :: grp, space, dset, attr_space, attr
+    integer(kind=4)    :: ierr
+    logical(kind=4)    :: exists
+    integer(HSIZE_T)   :: dims(1), adims(1)
 
-    if (dbg_file .lt. 0) return
+    if (dbg_file <= 0) return
     if (present(step)) then
       write(dset_name, '(a,"_step",i4.4)') trim(name), step
     else
@@ -178,7 +181,7 @@ contains
     end if
 
     dims(1) = int(size(arr), HSIZE_T)
-    call h5screate_simple_f(1, dims, space, ierr)
+    call h5screate_simple_f(int(1,kind=4), dims, space, ierr)
     call h5lexists_f(grp, trim(dset_name), exists, ierr)
     if (.not. exists) then
       call h5dcreate_f(grp, trim(dset_name), H5T_NATIVE_INTEGER, space, dset, ierr)
@@ -188,7 +191,8 @@ contains
     call h5dwrite_f(dset, H5T_NATIVE_INTEGER, arr, dims, ierr)
     call h5sclose_f(space, ierr)
 
-    call h5screate_simple_f(1, (/1_HSIZE_T/), attr_space, ierr)
+    adims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), adims, attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
     call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)
@@ -200,15 +204,15 @@ contains
 
   subroutine dbg_log_msg(group, msg, step)
     character(len=*), intent(in) :: group, msg
-    integer, intent(in), optional :: step
+    integer(kind=4), intent(in), optional :: step
     character(len=256) :: dset_name
-    integer(HID_T) :: grp, space, dset, dtype, attr_space, attr
-    integer :: ierr
-    logical(kind=4) :: exists
-    integer(HSIZE_T), dimension(1) :: dims, adims = (/1_HSIZE_T/)
-    integer(SIZE_T) :: len
+    integer(HID_T)     :: grp, space, dset, dtype, attr_space, attr
+    integer(kind=4)    :: ierr
+    logical(kind=4)    :: exists
+    integer(HSIZE_T)   :: dims(1), adims(1)
+    integer(SIZE_T)    :: len
 
-    if (dbg_file .lt. 0) return
+    if (dbg_file <= 0) return
     if (present(step)) then
       write(dset_name, '(a,"_step",i4.4)') 'log', step
     else
@@ -221,8 +225,8 @@ contains
     end if
 
     len = int(len_trim(msg), SIZE_T)
-    dims(1) = 1_HSIZE_T
-    call h5screate_simple_f(1, dims, space, ierr)
+    dims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), dims, space, ierr)
     call h5tcopy_f(H5T_C_S1, dtype, ierr)
     call h5tset_size_f(dtype, len, ierr)
     call h5lexists_f(grp, trim(dset_name), exists, ierr)
@@ -234,7 +238,8 @@ contains
     call h5dwrite_f(dset, dtype, msg(1:int(len)), dims, ierr)
 
     ! rank attribute
-    call h5screate_simple_f(1, (/1_HSIZE_T/), attr_space, ierr)
+    adims(1) = int(1, kind=HSIZE_T)
+    call h5screate_simple_f(int(1,kind=4), adims, attr_space, ierr)
     call h5acreate_f(dset, "rank", H5T_NATIVE_INTEGER, attr_space, attr, ierr)
     call h5awrite_f(attr, H5T_NATIVE_INTEGER, dbg_rank, adims, ierr)
     call h5aclose_f(attr, ierr)


### PR DESCRIPTION
## Summary
- Ensure all integers passed to HDF5 have explicit kind=4 to prevent NVFORTRAN kind mismatches
- Initialize HDF5 dimension arrays explicitly and use consistent file handle management

## Testing
- `gfortran -c src/gnome/debug_hdf5.F90` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a34a9536ec832a978240678949d4f5